### PR TITLE
Added integration for sphinx.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ help:
 	@echo "  clean       to clean everything"
 	@echo "  venv        to create the virtualenv and install dependencies"
 	@echo "  dist        to build the package"
+	@echo "  docs        to build the HTML documentation"
 	@echo "  install     to install the package in the vitualenv"
 	@echo "  reinstall   to rebuild and reinstall the package in the vitualenv"
 	@echo "  tests    	 to run the lint checks and tests"
@@ -61,6 +62,10 @@ $(frontend)/node_modules:
 
 $(frontend)/dist: $(frontend)/node_modules
 	cd $(frontend) && $(nvm) use && npm run dev
+
+.PHONY: docs
+docs:
+	python setup.py build_sphinx
 
 .PHONY: install
 install: venv dist

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ author = 'Rolo Mawlabaux'
 # The short X.Y version.
 version = "0.0.1"
 # The full version, including alpha/beta/rc tags.
-release = version
+release = "0.0.1"
 
 # -- General configuration ---------------------------------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -112,3 +112,7 @@ deps =
 commands =
     make install-packages
     pytest
+
+[build_sphinx]
+source-dir = docs
+build-dir = docs/_build


### PR DESCRIPTION
Setup the inegration between sphinx and setuptools by adding a section
to setup.cgf. Just the source and build dirs were given as the project
name and version numbers will be picked up from conf.py. The build
directory was chosen to be the same as the one used when building using
the makefile in the docs directory so the generated HTML is always in
the same place (the default was to generate it in the build directory
in the root - where the packages are built).

Added a docs target to the makefile to trigger building the HTML docs
using setup.py.

Changed the release in docs/conf.py to be set separately from version.
Ideally version is just the major and minor release numbers whereas
release is the full version number, e.g. 1.2.3b1, etc.