### PR TITLE
Added support for textareas.

### DIFF
--- a/demo/backend/fields/forms/__init__.py
+++ b/demo/backend/fields/forms/__init__.py
@@ -1,2 +1,2 @@
-from .checkboxes import CheckboxesForm
 from .text_input import TextInputForm
+from .textarea import TextareaForm

--- a/demo/backend/fields/forms/textarea.py
+++ b/demo/backend/fields/forms/textarea.py
@@ -1,0 +1,36 @@
+from crispy_forms.layout import Field, Layout
+from django import forms
+from django.forms import TextInput, Textarea
+from django.utils.translation import ugettext_lazy as _
+
+from crispy_forms.helper import FormHelper
+from crispy_forms_gds.layout import Submit
+
+
+class TextareaForm(forms.Form):
+
+    use_required_attribute = False
+
+    description = forms.CharField(
+        label=_("Can you provide more detail?"),
+        widget=Textarea,
+        help_text=_(
+            "Do not include personal or financial information, like your "
+            "National Insurance number or credit card details. ."
+        ),
+        error_messages={"required": _("Enter a short description of your application")},
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(TextareaForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.layout = Layout(
+            Field(
+                "description",
+                css_class="govuk-textarea",
+                autocomplete="off",
+                spellcheck="true",
+                rows=3,
+            ),
+            Submit("submit", "Submit"),
+        )

--- a/demo/backend/fields/templates/fields/base.html
+++ b/demo/backend/fields/templates/fields/base.html
@@ -10,6 +10,12 @@
            {% trans 'Text input' %}
         </a>
       </li>
+      <li>
+        <a href="{% url 'fields:name' 'textarea' %}"
+           class="govuk-link govuk-link--no-visited-state">
+           {% trans 'Textarea' %}
+        </a>
+      </li>
     </ul>
   </nav>
 {% endblock %}

--- a/demo/backend/fields/templates/fields/textarea.html
+++ b/demo/backend/fields/templates/fields/textarea.html
@@ -1,0 +1,16 @@
+{% extends "fields/base.html" %}
+{% load i18n crispy_forms_tags %}
+
+{% block content %}
+  <span class="govuk-caption-xl">
+    {% trans 'Fields' %}
+  </span>
+  <h1 class="govuk-heading-l">
+    {% trans 'Textarea' %}
+  </h1>
+
+  <div class="govuk-body">
+    {% crispy form %}
+  </div>
+
+{% endblock %}

--- a/demo/backend/fields/views.py
+++ b/demo/backend/fields/views.py
@@ -1,18 +1,18 @@
 from django.views.generic.edit import FormView
 from django.urls import reverse_lazy
 
-from .forms import TextInputForm, CheckboxesForm
+from .forms import TextareaForm, TextInputForm
 
 
 class FieldView(FormView):
     success_url = reverse_lazy("fields:index")
     form_classes = {
-        "checkboxes": CheckboxesForm,
         "text-input": TextInputForm,
+        "textarea": TextareaForm,
     }
     templates = {
-        "checkboxes": "fields/checkboxes.html",
         "text-input": "fields/text-input.html",
+        "textarea": "fields/textarea.html",
     }
 
     def get_template_names(self):

--- a/demo/backend/settings.py
+++ b/demo/backend/settings.py
@@ -76,4 +76,7 @@ CRISPY_TEMPLATE_PACK = "gds"
 
 # Map the names for the different widget classes to a CSS class that will
 # be added when the widget is rendered.
-CRISPY_CLASS_CONVERTERS = {"textinput": ""}
+CRISPY_CLASS_CONVERTERS = {
+    "textinput": "",
+    "textarea": "",
+}

--- a/src/crispy_forms_gds/templatetags/crispy_forms_gds_field.py
+++ b/src/crispy_forms_gds/templatetags/crispy_forms_gds_field.py
@@ -166,7 +166,7 @@ class CrispyGDSFieldNode(template.Node):
 
             if template_pack == "gds":
 
-                if widget.__class__.__name__ == "TextInput":
+                if widget.__class__.__name__ in ["TextInput", "Textarea"]:
 
                     if field.help_text:
                         widget.attrs["aria-describedby"] = "%s_hint" % field.auto_id

--- a/tests/fields/results/textarea/initial.html
+++ b/tests/fields/results/textarea/initial.html
@@ -1,0 +1,17 @@
+<form method="post">
+  <div id="div_id_name" class="govuk-form-group">
+    <label for="id_name" class="govuk-label">
+      Name
+    </label>
+    <div id="id_name_hint" class="govuk-hint">
+      Help text
+    </div>
+    <textarea name="name"
+           aria-describedby="id_name_hint"
+           class="govuk-textarea"
+           id="id_name"
+           rows="10"
+           cols="40">
+    </textarea>
+  </div>
+</form>

--- a/tests/fields/results/textarea/validation_errors.html
+++ b/tests/fields/results/textarea/validation_errors.html
@@ -1,0 +1,20 @@
+<form method="post">
+  <div id="div_id_name" class="govuk-form-group govuk-form-group--error">
+    <label for="id_name" class="govuk-label">
+      Name
+    </label>
+    <div id="id_name_hint" class="govuk-hint">
+      Help text
+    </div>
+    <span id="id_name_1_error" class="govuk-error-message">
+      <span class="govuk-visually-hidden">Error:</span> Required error message
+    </span>
+    <textarea name="name"
+           aria-describedby="id_name_hint id_name_1_error"
+           class="govuk-textarea govuk-input--error"
+           id="id_name"
+           rows="10"
+           cols="40">
+    </textarea>
+  </div>
+</form>

--- a/tests/fields/test_textarea.py
+++ b/tests/fields/test_textarea.py
@@ -1,0 +1,23 @@
+"""
+Tests to verify textareas are rendered correctly.
+
+"""
+import os
+
+from tests.forms import TextareaForm
+from tests.utils import TEST_DIR, parse_form, parse_contents
+
+RESULT_DIR = os.path.join(TEST_DIR, "fields", "results", "textarea")
+
+
+def test_initial_attributes():
+    """Verify all the gds attributes are displayed."""
+    form = TextareaForm()
+    assert parse_form(form) == parse_contents(RESULT_DIR, "initial.html")
+
+
+def test_validation_error_attributes():
+    """Verify all the gds error attributes are displayed."""
+    form = TextareaForm(data={"field_name": ""})
+    assert not form.is_valid()
+    assert parse_form(form) == parse_contents(RESULT_DIR, "validation_errors.html")

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -1,6 +1,7 @@
 from django import forms
 
 from crispy_forms.helper import FormHelper
+from django.forms import Textarea
 
 
 class BaseForm(forms.Form):
@@ -15,6 +16,18 @@ class TextInputForm(BaseForm):
 
     name = forms.CharField(
         label="Name",
+        help_text="Help text",
+        error_messages={"required": "Required error message"},
+    )
+
+
+class TextareaForm(BaseForm):
+
+    use_required_attribute = False
+
+    name = forms.CharField(
+        label="Name",
+        widget=Textarea,
         help_text="Help text",
         error_messages={"required": "Required error message"},
     )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -23,4 +23,7 @@ CRISPY_ALLOWED_TEMPLATE_PACKS = ("gds",)
 
 CRISPY_TEMPLATE_PACK = "gds"
 
-CRISPY_CLASS_CONVERTERS = {"textinput": "govuk-input"}
+CRISPY_CLASS_CONVERTERS = {
+    "textinput": "govuk-input",
+    "textarea": "govuk-textarea",
+}


### PR DESCRIPTION
The widget is rendered using the default Django templates (that's just the
way crispy forms works). So aria level attributes are added when the field
is rendered.

Support for character counts will be added later.