### PR TITLE
Adding support for buttons.

### DIFF
--- a/demo/backend/fields/forms/__init__.py
+++ b/demo/backend/fields/forms/__init__.py
@@ -1,3 +1,4 @@
+from .buttons import ButtonsForm
 from .checkboxes import CheckboxesForm
 from .file_upload import FileUploadForm
 from .radios import RadiosForm

--- a/demo/backend/fields/forms/buttons.py
+++ b/demo/backend/fields/forms/buttons.py
@@ -1,0 +1,45 @@
+from django import forms
+
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Field, Layout
+
+from crispy_forms_gds.layout import Button
+
+
+class ButtonsForm(forms.Form):
+
+    use_required_attribute = False
+
+    name = forms.CharField(required=False)
+
+    def __init__(self, *args, **kwargs):
+        super(ButtonsForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.layout = Layout(
+            Field("name", css_class="govuk-input"),
+            Button(
+                "primary",
+                "Primary button",
+                css_class="govuk-button",
+                data_module="govuk-button",
+            ),
+            Button(
+                "secondary",
+                "Secondary button",
+                css_class="govuk-button--secondary",
+                data_module="govuk-button",
+            ),
+            Button(
+                "disabled",
+                "Disabled button",
+                disabled="disabled",
+                aria_disabled="true",
+                data_module="govuk-button",
+            ),
+            Button(
+                "warning",
+                "Warning button",
+                css_class="govuk-button--warning",
+                data_module="govuk-button",
+            ),
+        )

--- a/demo/backend/fields/templates/fields/base.html
+++ b/demo/backend/fields/templates/fields/base.html
@@ -5,6 +5,12 @@
   <nav>
     <ul class="govuk-list">
       <li>
+        <a href="{% url 'fields:name' 'buttons' %}"
+           class="govuk-link govuk-link--no-visited-state">
+           {% trans 'Buttons' %}
+        </a>
+      </li>
+      <li>
         <a href="{% url 'fields:name' 'checkboxes' %}"
            class="govuk-link govuk-link--no-visited-state">
            {% trans 'Checkboxes' %}

--- a/demo/backend/fields/templates/fields/buttons.html
+++ b/demo/backend/fields/templates/fields/buttons.html
@@ -1,0 +1,16 @@
+{% extends "fields/base.html" %}
+{% load i18n crispy_forms_tags %}
+
+{% block content %}
+  <span class="govuk-caption-xl">
+    {% trans 'Fields' %}
+  </span>
+  <h1 class="govuk-heading-l">
+    {% trans 'Buttons' %}
+  </h1>
+
+  <div class="govuk-body">
+    {% crispy form %}
+  </div>
+
+{% endblock %}

--- a/demo/backend/fields/views.py
+++ b/demo/backend/fields/views.py
@@ -2,6 +2,7 @@ from django.views.generic.edit import FormView
 from django.urls import reverse_lazy
 
 from .forms import (
+    ButtonsForm,
     CheckboxesForm,
     FileUploadForm,
     RadiosForm,
@@ -14,6 +15,7 @@ from .forms import (
 class FieldView(FormView):
     success_url = reverse_lazy("fields:index")
     form_classes = {
+        "buttons": ButtonsForm,
         "checkboxes": CheckboxesForm,
         "file-upload": FileUploadForm,
         "radios": RadiosForm,
@@ -22,6 +24,7 @@ class FieldView(FormView):
         "textarea": TextareaForm,
     }
     templates = {
+        "buttons": "fields/buttons.html",
         "checkboxes": "fields/checkboxes.html",
         "file-upload": "fields/file-upload.html",
         "radios": "fields/radios.html",

--- a/src/crispy_forms_gds/layout.py
+++ b/src/crispy_forms_gds/layout.py
@@ -12,3 +12,19 @@ class Submit(BaseInput):
 
     input_type = "submit"
     field_classes = "govuk-button"
+
+
+class Button(BaseInput):
+    """
+    Used to create a button of any type::
+
+        button = Button('Button 1', 'Press Me!')
+
+    .. note:: The first argument is also slugified and turned into the id for the button.
+    """
+
+    template = "gds/layout/button.html"
+    field_classes = "govuk-button"
+
+    def __init__(self, name, value, **kwargs):
+        super().__init__(name, value, **kwargs)

--- a/src/crispy_forms_gds/templates/gds/layout/button.html
+++ b/src/crispy_forms_gds/templates/gds/layout/button.html
@@ -1,0 +1,5 @@
+<button name="{% if input.name|wordcount > 1 %}{{ input.name|slugify }}{% else %}{{ input.name }}{% endif %}"
+        class="{{ input.field_classes }}"
+        id="{% if input.id %}{{ input.id }}{% else %}id_{{ input.name|slugify }}{% endif %}"
+        {{ input.flat_attrs|safe }}
+>{{ input.value|safe }}</button>

--- a/tests/fields/results/buttons/initial.html
+++ b/tests/fields/results/buttons/initial.html
@@ -1,0 +1,25 @@
+<form method="post">
+
+  <button name="primary"
+          class="govuk-button"
+          id="id_primary"
+          data-module="govuk-button">Primary button</button>
+
+  <button name="secondary"
+          class="govuk-button govuk-button--secondary"
+          id="id_secondary"
+          data-module="govuk-button">Secondary button</button>
+
+  <button name="disabled"
+          class="govuk-button"
+          disabled="disabled"
+          id="id_disabled"
+          aria-disabled="true"
+          data-module="govuk-button">Disabled button</button>
+
+  <button name="warning"
+          class="govuk-button govuk-button--warning"
+          id="id_warning"
+          data-module="govuk-button">Warning button</button>
+
+</form>

--- a/tests/fields/test_buttons.py
+++ b/tests/fields/test_buttons.py
@@ -1,0 +1,16 @@
+"""
+Tests to verify text fields are rendered correctly.
+
+"""
+import os
+
+from tests.forms import ButtonsForm
+from tests.utils import TEST_DIR, parse_form, parse_contents
+
+RESULT_DIR = os.path.join(TEST_DIR, "fields", "results", "buttons")
+
+
+def test_initial_attributes():
+    """Verify all the gds attributes are displayed."""
+    form = ButtonsForm()
+    assert parse_form(form) == parse_contents(RESULT_DIR, "initial.html")

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -1,14 +1,44 @@
-from crispy_forms.layout import Submit
 from django import forms
+from django.forms import CheckboxSelectMultiple, RadioSelect, Select, Textarea
 
 from crispy_forms.helper import FormHelper
-from django.forms import CheckboxSelectMultiple, RadioSelect, Select, Textarea
+from crispy_forms.layout import Layout, Submit
+
+from crispy_forms_gds.layout import Button
 
 
 class BaseForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper = kwargs.pop("helper", FormHelper())
+
+
+class ButtonsForm(forms.Form):
+    def __init__(self, *args, **kwargs):
+        super(ButtonsForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.layout = Layout(
+            Button("primary", "Primary button", data_module="govuk-button"),
+            Button(
+                "secondary",
+                "Secondary button",
+                css_class="govuk-button--secondary",
+                data_module="govuk-button",
+            ),
+            Button(
+                "disabled",
+                "Disabled button",
+                disabled="disabled",
+                aria_disabled="true",
+                data_module="govuk-button",
+            ),
+            Button(
+                "warning",
+                "Warning button",
+                css_class="govuk-button--warning",
+                data_module="govuk-button",
+            ),
+        )
 
 
 class TextInputForm(BaseForm):


### PR DESCRIPTION
The layout template, gds/layout/baseinput.html will render instances of
the Submit and Button classes as <input> elements. The Button class was
overridden and a new layout template, gds/layout/button was added so the
objects are rendered as <button> elements with the correct classes added.