### PR TITLE
CRISPY_CLASS_CONVERTERS setting is no longer used for initial configuration

### DIFF
--- a/demo/backend/fields/forms/file_upload.py
+++ b/demo/backend/fields/forms/file_upload.py
@@ -18,7 +18,4 @@ class FileUploadForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super(FileUploadForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
-        self.helper.layout = Layout(
-            Field("file", css_class="govuk-file-upload",),
-            Submit("submit", _("Submit")),
-        )
+        self.helper.add_input(Submit("submit", _("Submit")))

--- a/demo/backend/fields/forms/select.py
+++ b/demo/backend/fields/forms/select.py
@@ -23,6 +23,4 @@ class SelectForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super(SelectForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
-        self.helper.layout = Layout(
-            Field("method", css_class="govuk-select"), Submit("submit", _("Submit")),
-        )
+        self.helper.add_input(Submit("submit", _("Submit")))

--- a/demo/backend/fields/forms/text_input.py
+++ b/demo/backend/fields/forms/text_input.py
@@ -34,22 +34,17 @@ class TextInputForm(forms.Form):
         super(TextInputForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.layout = Layout(
-            Field(
-                "name",
-                css_class="govuk-input",
-                autocomplete="name",
-                spellcheck="false",
-            ),
+            Field("name", autocomplete="name", spellcheck="false",),
             Field(
                 "email",
                 type="email",
-                css_class="govuk-input govuk-!-width-one-half",
+                css_class="govuk-!-width-one-half",
                 autocomplete="email",
                 spellcheck="false",
             ),
             Field(
                 "age",
-                css_class="govuk-input govuk-input--width-3",
+                css_class="govuk-input--width-3",
                 pattern="[0-9]*",
                 inputmode="numeric",
             ),

--- a/demo/backend/fields/forms/textarea.py
+++ b/demo/backend/fields/forms/textarea.py
@@ -21,12 +21,6 @@ class TextareaForm(forms.Form):
         super(TextareaForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.layout = Layout(
-            Field(
-                "description",
-                css_class="govuk-textarea",
-                autocomplete="off",
-                spellcheck="true",
-                rows=3,
-            ),
+            Field("description", autocomplete="off", spellcheck="true", rows=3,),
             Submit("submit", _("Submit")),
         )

--- a/demo/backend/settings.py
+++ b/demo/backend/settings.py
@@ -73,12 +73,3 @@ STATICFILES_DIRS = (os.path.join(FRONTEND_DIR, "dist"),)
 CRISPY_ALLOWED_TEMPLATE_PACKS = ("gds",)
 
 CRISPY_TEMPLATE_PACK = "gds"
-
-# Map the names for the different widget classes to a CSS class that will
-# be added when the widget is rendered.
-CRISPY_CLASS_CONVERTERS = {
-    "select": "",
-    "textinput": "",
-    "textarea": "",
-    "clearablefileinput": "",
-}

--- a/src/crispy_forms_gds/templatetags/crispy_forms_gds_field.py
+++ b/src/crispy_forms_gds/templatetags/crispy_forms_gds_field.py
@@ -125,9 +125,10 @@ class CrispyGDSFieldNode(template.Node):
             attrs = [attrs] * len(widgets)
 
         converters = {
-            "textinput": "textinput textInput",
-            "fileinput": "fileinput fileUpload",
-            "passwordinput": "textinput textInput",
+            "select": "govuk-select",
+            "textinput": "govuk-input",
+            "textarea": "govuk-textarea",
+            "clearablefileinput": "govuk-file-upload",
         }
         converters.update(getattr(settings, "CRISPY_CLASS_CONVERTERS", {}))
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -22,10 +22,3 @@ TEMPLATES = [
 CRISPY_ALLOWED_TEMPLATE_PACKS = ("gds",)
 
 CRISPY_TEMPLATE_PACK = "gds"
-
-CRISPY_CLASS_CONVERTERS = {
-    "select": "govuk-select",
-    "textinput": "govuk-input",
-    "textarea": "govuk-textarea",
-    "clearablefileinput": "govuk-file-upload",
-}


### PR DESCRIPTION
The field template tag was updated to map the widget class names to the set
of CSS classes needed to render the respective wiget as a Design System
component. As a result the CRISPY_CLASS_CONVERTERS setting is no longer
needed as part of the basic configuration of the template pack and can be
used as it was originally intended as a way of overriding the CSS classes
used.