### PR TITLE
Simplified templates for setting label and legends.

### DIFF
--- a/demo/backend/components/forms/complete.py
+++ b/demo/backend/components/forms/complete.py
@@ -53,7 +53,8 @@ class CompleteForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()
-        self.helper.field_label_size = "m"
+        self.helper.label_size = "m"
+        self.helper.legend_size = "m"
         self.helper.layout = Layout(
             Field("text_input", css_class="govuk-!-width-one-half"),
             Field("textarea", rows="3"),

--- a/demo/backend/components/forms/text_input.py
+++ b/demo/backend/components/forms/text_input.py
@@ -33,7 +33,8 @@ class TextInputForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super(TextInputForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
-        self.helper.field_label_size = Size.MEDIUM
+        self.helper.label_size = Size.MEDIUM
+        self.helper.legend_size = Size.MEDIUM
         self.helper.layout = Layout(
             "name",
             Field.text("email", field_width=Fluid.ONE_HALF),

--- a/docs/cookbook/basics/changing_label_sizes.rst
+++ b/docs/cookbook/basics/changing_label_sizes.rst
@@ -13,7 +13,7 @@ There are two ways you can set the size of a label or legend:
 1. Globally, for every field on a form.
 2. Locally, for any field on a case-by-case basis.
 
-To set the labels size globally, set the `field_label_size` attribute on the
+To set the labels size globally, set the `label_size` attribute on the
 ``FormHelper`` class when you define the layout for a form: ::
 
     from django import forms
@@ -28,7 +28,7 @@ To set the labels size globally, set the `field_label_size` attribute on the
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
             self.helper = FormHelper()
-            self.helper.field_label_size = Size.LARGE
+            self.helper.label_size = Size.LARGE
             self.helper.add_input(Submit("submit", "Submit"))
 
 To set the label size for an individual field, you can set the ``label_size``
@@ -51,7 +51,7 @@ argument on theField class methods: ::
                 Submit("submit", "Submit")
             )
 
-Alternatively set the ``field_label_size`` template variable in the context when
+Alternatively set the ``label_size`` template variable in the context when
 creating a ``Field`` object directly: ::
 
     from django import forms
@@ -67,6 +67,6 @@ creating a ``Field`` object directly: ::
             super().__init__(*args, **kwargs)
             self.helper = FormHelper()
             self.helper.layout = Layout(
-                Field("name", context={"field_label_size": Size.LARGE}),
+                Field("name", context={"label_size": Size.LARGE}),
                 Submit("submit", "Submit")
             )

--- a/docs/cookbook/basics/labels_as_headings.rst
+++ b/docs/cookbook/basics/labels_as_headings.rst
@@ -4,11 +4,11 @@ Making labels and legends headings
 When there is only one question on a page you can make the label associated with
 a field the title of the page. To do that the field label or legend needs to be
 wrapped in an ``<h1>`` element - it's not enough just to change the size of the
-label or omit the label and add the ``<h1>`` tag instead, as that will confuse
+label or omit the label and add the heading tag instead, as that will confuse
 screen readers.
 
 You can do this easily enough on the ``Field`` class methods but setting the
-``label_is_heading`` argument to ``True``: ::
+``label_tag`` argument to ``h1``: ::
 
     from django import forms
 
@@ -23,7 +23,7 @@ You can do this easily enough on the ``Field`` class methods but setting the
             super().__init__(*args, **kwargs)
             self.helper = FormHelper()
             self.helper.layout = Layout(
-                Field.text("name", label_size="l", label_is_heading=True),
+                Field.text("name", label_size="l", label_tag="h1"),
                 Submit("submit", "Submit"),
             )
 
@@ -48,8 +48,8 @@ set this manually on a ``Field`` instance: ::
             self.helper = FormHelper()
             self.helper.layout = Layout(
                 Field("name", context={
-                    "field_label_size": Size.LARGE,
-                    "field_label_is_heading": True
+                    "label_size": Size.LARGE,
+                    "label_tag": "h1"
                 }),
                 Submit("submit", "Submit")
             )

--- a/src/crispy_forms_gds/helper.py
+++ b/src/crispy_forms_gds/helper.py
@@ -18,19 +18,26 @@ class FormHelper(crispy_forms_helper.FormHelper):
             the attribute as it triggers the browser to interfere with the way
             field errors are shown.
 
-        **field_label_size**: if not None, make labels bold and larger than the
+        **label_size**: if not None, make labels bold and larger than the
             default. Values can be 's', 'm', 'l' and 'xl'.
+
+        **legend_size**: if not None, make legends bold and larger than the
+            default. Values can be 's', 'm', 'l' and 'xl'. Generally this will
+            be the same size set for labels.
     """
 
     form_show_non_field_errors = False
     form_show_required_attribute = False
-    field_label_size = ""
+    label_size = ""
+    legend_size = ""
 
     def render_layout(self, form, context, template_pack=TEMPLATE_PACK):
         """
         Returns safe html of the rendering of the layout
         """
         form.use_required_attribute = self.form_show_required_attribute
-        if self.field_label_size:
-            context["field_label_size"] = self.field_label_size
+        if self.label_size:
+            context["label_size"] = self.label_size
+        if self.legend_size:
+            context["legend_size"] = self.legend_size
         return super().render_layout(form, context, template_pack=template_pack)

--- a/src/crispy_forms_gds/layout/fields.py
+++ b/src/crispy_forms_gds/layout/fields.py
@@ -113,9 +113,7 @@ class Field(crispy_forms_layout.LayoutObject):
     template = "%s/field.html"
 
     @classmethod
-    def text(
-        cls, field, label_size=None, label_is_heading=False, field_width=None, **kwargs
-    ):
+    def text(cls, field, label_size=None, label_tag=None, field_width=None, **kwargs):
         """
         Create a field for displaying a Text input.
 
@@ -125,8 +123,8 @@ class Field(crispy_forms_layout.LayoutObject):
             label_size (str): the size of the label. The default is None in which
                 case the label will be rendered at the same size as regular text.
 
-            label_is_heading (bool): Use the field label as the page title.
-                Default is False.
+            label_tag (str): Wrap the field label with this HTML tag.
+                Default is None.
 
             field_width (int, str): the width of the field - fixed or fluid. The
                 default is None in which case the field will be rendered full width.
@@ -142,10 +140,10 @@ class Field(crispy_forms_layout.LayoutObject):
         context = {}
 
         if label_size:
-            context["field_label_size"] = Size.clean(label_size)
+            context["label_size"] = Size.clean(label_size)
 
-        if label_is_heading:
-            context["field_label_is_heading"] = True
+        if label_tag:
+            context["label_tag"] = label_tag
 
         if field_width:
             if isinstance(field_width, int):
@@ -178,7 +176,7 @@ class Field(crispy_forms_layout.LayoutObject):
 
         Examples::
 
-            Field('name', context={'field_label_is_heading': True, 'field_label_size': 'govuk-label--xl'})
+            Field('name', context={'label_tag': 'h1', 'label_size': 'govuk-label--xl'})
             Field('age', css_class="govuk-input-width-5", style="color: #333;")
 
         """
@@ -266,22 +264,8 @@ class Field(crispy_forms_layout.LayoutObject):
             {k.replace("_", "-"): conditional_escape(v) for k, v in kwargs.items()}
         )
 
-    def render(
-        self,
-        form,
-        form_style,
-        context,
-        template_pack=TEMPLATE_PACK,
-        extra_context=None,
-        **kwargs
-    ):
-        if extra_context is None:
-            extra_context = {}
-
-        extra_context.update(self.context)
-
+    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
         template = self.get_template_name(template_pack)
-
         return self.get_rendered_fields(
             form,
             form_style,
@@ -289,7 +273,7 @@ class Field(crispy_forms_layout.LayoutObject):
             template_pack,
             template=template,
             attrs=self.attrs,
-            extra_context=extra_context,
+            extra_context=self.context,
             **kwargs,
         )
 

--- a/src/crispy_forms_gds/templates/gds/field.html
+++ b/src/crispy_forms_gds/templates/gds/field.html
@@ -16,11 +16,11 @@
     {% if not field|is_checkboxselectmultiple and not field|is_radioselect %}
 
       {% if field.label and not field|is_checkbox and form_show_labels %}
-        {% if field_label_is_heading %}<h1 class="govuk-label-wrapper">{% endif %}
-        <label for="{{ field.id_for_label }}" class="govuk-label{% if field_label_size %} govuk-label--{{ field_label_size }}{% endif %}">
+        {% if label_tag %}<{{ label_tag }} class="govuk-label-wrapper">{% endif %}
+        <label for="{{ field.id_for_label }}" class="govuk-label{% if label_size %} govuk-label--{{ label_size }}{% endif %}">
           {{ field.label|safe }}
         </label>
-        {% if field_label_is_heading %}</h1>{% endif %}
+        {% if label_tag %}</{{ label_tag }}>{% endif %}
       {% endif %}
 
       {% if field|is_checkbox and form_show_labels %}

--- a/src/crispy_forms_gds/templates/gds/layout/checkboxes.html
+++ b/src/crispy_forms_gds/templates/gds/layout/checkboxes.html
@@ -2,10 +2,10 @@
 <fieldset class="govuk-fieldset"{% if field.help_text or field.errors %} aria-describedby="{% if field.help_text %}id_method_hint{% endif %}{% for error in field.errors %} {{ field.auto_id }}_{{ forloop.counter }}_error{% endfor %}"{% endif %}>
 
   {% if field.label %}
-    <legend class="govuk-fieldset__legend{% if field_label_size %} govuk-fieldset__legend--{{ field_label_size }}{% endif %}">
-      {% if field_label_is_heading %}<h1 class="govuk-fieldset__heading">{% endif %}
+    <legend class="govuk-fieldset__legend{% if legend_size %} govuk-fieldset__legend--{{ legend_size }}{% endif %}">
+      {% if legend_tag %}<{{ legend_tag }} class="govuk-fieldset__heading">{% endif %}
       {{ field.label|safe }}
-      {% if field_label_is_heading %}</h1>{% endif %}
+      {% if legend_tag %}</{{ legend_tag }}>{% endif %}
     </legend>
   {% endif %}
 

--- a/src/crispy_forms_gds/templates/gds/layout/radios.html
+++ b/src/crispy_forms_gds/templates/gds/layout/radios.html
@@ -2,10 +2,10 @@
 <fieldset class="govuk-fieldset"{% if field.help_text or field.errors %} aria-describedby="{% if field.help_text %}id_method_hint{% endif %}{% for error in field.errors %} {{ field.auto_id }}_{{ forloop.counter }}_error{% endfor %}"{% endif %}>
 
   {% if field.label %}
-    <legend class="govuk-fieldset__legend{% if field_label_size %} govuk-fieldset__legend--{{ field_label_size }}{% endif %}">
-      {% if field_label_is_heading %}<h1 class="govuk-fieldset__heading">{% endif %}
+    <legend class="govuk-fieldset__legend{% if legend_size %} govuk-fieldset__legend--{{ legend_size }}{% endif %}">
+      {% if legend_tag %}<{{ legend_tag }} class="govuk-fieldset__heading">{% endif %}
       {{ field.label|safe }}
-      {% if field_label_is_heading %}</h1>{% endif %}
+      {% if legend_tag %}</{{ legend_tag }}>{% endif %}
     </legend>
   {% endif %}
 

--- a/tests/fields/test_checkboxes.py
+++ b/tests/fields/test_checkboxes.py
@@ -30,9 +30,7 @@ def test_show_legend_as_heading():
     """Verify the field legend can be displayed as the page heading."""
     form = CheckboxesForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(
-        Field("method", context=dict(field_label_is_heading=True))
-    )
+    form.helper.layout = Layout(Field("method", context=dict(legend_tag="h1")))
     assert parse_form(form) == parse_contents(RESULT_DIR, "legend_heading.html")
 
 
@@ -40,7 +38,7 @@ def test_change_legend_size():
     """Verify size of the field legend can be changed from the default."""
     form = CheckboxesForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(Field("method", context=dict(field_label_size="l")))
+    form.helper.layout = Layout(Field("method", context=dict(legend_size="l")))
     assert parse_form(form) == parse_contents(RESULT_DIR, "legend_size.html")
 
 

--- a/tests/fields/test_file_upload.py
+++ b/tests/fields/test_file_upload.py
@@ -30,9 +30,7 @@ def test_show_label_as_heading():
     """Verify the field label can be displayed as the page heading."""
     form = FileUploadForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(
-        Field("file", context=dict(field_label_is_heading=True))
-    )
+    form.helper.layout = Layout(Field("file", context=dict(label_tag="h1")))
     assert parse_form(form) == parse_contents(RESULT_DIR, "label_heading.html")
 
 
@@ -40,7 +38,7 @@ def test_change_label_size():
     """Verify size of the field label can be changed from the default."""
     form = FileUploadForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(Field("file", context=dict(field_label_size="l")))
+    form.helper.layout = Layout(Field("file", context=dict(label_size="l")))
     assert parse_form(form) == parse_contents(RESULT_DIR, "label_size.html")
 
 

--- a/tests/fields/test_radios.py
+++ b/tests/fields/test_radios.py
@@ -30,9 +30,7 @@ def test_show_legend_as_heading():
     """Verify the field legend can be displayed as the page heading."""
     form = RadiosForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(
-        Field("method", context=dict(field_label_is_heading=True))
-    )
+    form.helper.layout = Layout(Field("method", context=dict(legend_tag="h1")))
     assert parse_form(form) == parse_contents(RESULT_DIR, "legend_heading.html")
 
 
@@ -40,7 +38,7 @@ def test_change_legend_size():
     """Verify size of the field legend can be changed from the default."""
     form = RadiosForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(Field("method", context=dict(field_label_size="l")))
+    form.helper.layout = Layout(Field("method", context=dict(legend_size="l")))
     assert parse_form(form) == parse_contents(RESULT_DIR, "legend_size.html")
 
 

--- a/tests/fields/test_select.py
+++ b/tests/fields/test_select.py
@@ -30,9 +30,7 @@ def test_show_label_as_heading():
     """Verify the field label can be displayed as the page heading."""
     form = SelectForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(
-        Field("method", context=dict(field_label_is_heading=True))
-    )
+    form.helper.layout = Layout(Field("method", context=dict(label_tag="h1")))
     assert parse_form(form) == parse_contents(RESULT_DIR, "label_heading.html")
 
 
@@ -40,7 +38,7 @@ def test_change_label_size():
     """Verify size of the field label can be changed from the default."""
     form = SelectForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(Field("method", context=dict(field_label_size="l")))
+    form.helper.layout = Layout(Field("method", context=dict(label_size="l")))
     assert parse_form(form) == parse_contents(RESULT_DIR, "label_size.html")
 
 

--- a/tests/fields/test_text_input.py
+++ b/tests/fields/test_text_input.py
@@ -30,9 +30,7 @@ def test_show_label_as_heading():
     """Verify the field label can be displayed as the page heading."""
     form = TextInputForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(
-        Field("name", context=dict(field_label_is_heading=True))
-    )
+    form.helper.layout = Layout(Field("name", context=dict(label_tag="h1")))
     assert parse_form(form) == parse_contents(RESULT_DIR, "label_heading.html")
 
 
@@ -40,7 +38,7 @@ def test_change_label_size():
     """Verify size of the field label can be changed from the default."""
     form = TextInputForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(Field("name", context=dict(field_label_size="l")))
+    form.helper.layout = Layout(Field("name", context=dict(label_size="l")))
     assert parse_form(form) == parse_contents(RESULT_DIR, "label_size.html")
 
 

--- a/tests/fields/test_textarea.py
+++ b/tests/fields/test_textarea.py
@@ -30,9 +30,7 @@ def test_show_label_as_heading():
     """Verify the field label can be displayed as the page heading."""
     form = TextareaForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(
-        Field("description", context=dict(field_label_is_heading=True))
-    )
+    form.helper.layout = Layout(Field("description", context=dict(label_tag="h1")))
     assert parse_form(form) == parse_contents(RESULT_DIR, "label_heading.html")
 
 
@@ -40,9 +38,7 @@ def test_change_label_size():
     """Verify size of the field label can be changed from the default."""
     form = TextareaForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(
-        Field("description", context=dict(field_label_size="l"))
-    )
+    form.helper.layout = Layout(Field("description", context=dict(label_size="l")))
     assert parse_form(form) == parse_contents(RESULT_DIR, "label_size.html")
 
 

--- a/tests/layout/test_field.py
+++ b/tests/layout/test_field.py
@@ -15,7 +15,7 @@ def test_text_field_defaults():
 
 def test_text_field_label_size():
     field = Field.text("name", label_size=Size.MEDIUM)
-    assert field.context["field_label_size"] == "m"
+    assert field.context["label_size"] == "m"
     assert field.attrs == {}
 
 


### PR DESCRIPTION
1. Simplified the template variable names for setting labels sizes
   from field_label_size to label_size.

2. Replaced label_is_heading with label_tag since there is nothing
   in the Design System documentation that says the label should
   always be wrapped in an \<h1> element. It will be when showing a
   single field on a page but you could equally show two fields from
   a form in which case you might want to wrap the labels in \<h2>
   tags.

3. Separated the variables for setting labels and legends. For fields
   they are the same thing but when fieldsets are taken into account
   it's possible that legends should be treated differently from
   labels. We'll see if this distinction works out or not.

4. Simplified the code when rendering a Field.