### PR TITLE
Added autodoc for rendering class docstrings.

### DIFF
--- a/docs/_static/css/gds.css
+++ b/docs/_static/css/gds.css
@@ -1,0 +1,13 @@
+.tag-blue { display: inline-block; font-weight: bold; color: #144e81; background-color: #d2e2f1; padding: 4px; }
+.tag-green { display: inline-block; font-weight: bold; color: #005a30; background-color: #cce2d8; padding: 4px; }
+.tag-grey { display: inline-block; font-weight: bold; color: #454a4d; background-color: #eff0f1; padding: 4px; }
+.tag-orange { display: inline-block; font-weight: bold; color: #6e3619; background-color: #fcd6c3; padding: 4px; }
+.tag-pink { display: inline-block; font-weight: bold; color: #80224d; background-color: #f7d7e6; padding: 4px; }
+.tag-purple { display: inline-block; font-weight: bold; color: #3d2375; background-color: #dbd5e9; padding: 4px; }
+.tag-red { display: inline-block; font-weight: bold; color: #942514; background-color: #f6d7d2; padding: 4px; }
+.tag-turquoise { display: inline-block; font-weight: bold; color: #10403c; background-color: #bfe3e0; padding: 4px; }
+.tag-yellow { display: inline-block; font-weight: bold; color: #594d00; background-color: #fff7bf; padding: 4px; }
+.font-small { font-weight: 700; font-size: 1rem; }
+.font-medium { font-weight: 700; font-size: 1.125rem; }
+.font-large { font-weight: 700; font-size: 1.5rem; }
+.font-extra-large { font-weight: 700; font-size: 2rem; }

--- a/docs/classes/buttons.rst
+++ b/docs/classes/buttons.rst
@@ -1,0 +1,17 @@
+=======
+Buttons
+=======
+
+######
+Button
+######
+
+.. autoclass:: crispy_forms_gds.layout.Button
+   :members:
+
+######
+Submit
+######
+
+.. autoclass:: crispy_forms_gds.layout.Submit
+   :members:

--- a/docs/classes/constants.rst
+++ b/docs/classes/constants.rst
@@ -1,0 +1,42 @@
+=======================
+Colours, Sizes & Widths
+=======================
+
+The Design System sets the colour, font-size and width of fields using CSS classes.
+Rather than deal with the CSS directly the template pack provides a set of (python)
+classes with constants for each of the values. After all, who wants to be typing
+something like ``govuk-!-width-three-quarters`` every time they want to set the width
+of a field?. The constants are translated into the respective CSS class when a widget
+is rendered.
+
+######
+Colour
+######
+
+.. autoclass:: crispy_forms_gds.layout.Colour
+   :members:
+
+##########
+Font Sizes
+##########
+
+.. autoclass:: crispy_forms_gds.layout.Size
+   :members:
+   :member-order: bysource
+
+############
+Fixed Widths
+############
+
+.. autoclass:: crispy_forms_gds.layout.Fixed
+   :members:
+   :member-order: bysource
+
+############
+Fluid Widths
+############
+
+.. autoclass:: crispy_forms_gds.layout.Fluid
+   :members:
+   :member-order: bysource
+

--- a/docs/classes/containers.rst
+++ b/docs/classes/containers.rst
@@ -1,0 +1,31 @@
+==========
+Containers
+==========
+
+#########
+Accordion
+#########
+
+.. automodule:: crispy_forms_gds.layout.Accordion
+   :members:
+
+.. automodule:: crispy_forms_gds.layout.AccordionSection
+   :members:
+
+########
+Fieldset
+########
+
+.. automodule:: crispy_forms_gds.layout.Fieldset
+   :members:
+
+
+####
+Tabs
+####
+
+.. automodule:: crispy_forms_gds.layout.Tabs
+   :members:
+
+.. automodule:: crispy_forms_gds.layout.TabPanel
+   :members:

--- a/docs/classes/content.rst
+++ b/docs/classes/content.rst
@@ -1,0 +1,10 @@
+=======
+Content
+=======
+
+####
+HTML
+####
+
+.. autoclass:: crispy_forms_gds.layout.HTML
+   :members:

--- a/docs/classes/fields.rst
+++ b/docs/classes/fields.rst
@@ -1,0 +1,17 @@
+======
+Fields
+======
+
+#####
+Field
+#####
+
+.. automodule:: crispy_forms_gds.layout.Field
+   :members:
+
+######
+Hidden
+######
+
+.. automodule:: crispy_forms_gds.layout.Hidden
+   :members:

--- a/docs/classes/helper.rst
+++ b/docs/classes/helper.rst
@@ -1,0 +1,7 @@
+==========
+FormHelper
+==========
+
+.. automodule:: crispy_forms_gds.helper
+   :members:
+

--- a/docs/classes/templatetags.rst
+++ b/docs/classes/templatetags.rst
@@ -1,0 +1,26 @@
+============
+Templatetags
+============
+
+############
+{% crispy %}
+############
+The crispy forms templatetag ``{% crispy form %}`` is still used to render
+the form since the template pack is simply a plugin. ::
+
+    {% load crispy_forms_tags %}
+    ...
+    {% if form.helper.form_show_errors and form.errors %}
+      {% include 'gds/layout/error_summary.html' %}
+    {% endif %}
+    ...
+    {% crispy form %}
+    ...
+
+
+######################
+{% crispy_gds_field %}
+######################
+
+.. automodule:: crispy_forms_gds.templatetags.crispy_forms_gds_field
+   :members:

--- a/docs/components/accordion.rst
+++ b/docs/components/accordion.rst
@@ -1,8 +1,8 @@
 .. _Accordion: https://design-system.service.gov.uk/components/accordion/
 
-=========
+#########
 Accordion
-=========
+#########
 There are two Layout classes for adding an `Accordion`_ to a form. ``AccordionSection``
 which wraps the contents of each section and ``Accordion`` which wraps the sections
 and adds the ability to open and collapse them. ::

--- a/docs/components/button.rst
+++ b/docs/components/button.rst
@@ -1,8 +1,8 @@
 .. _Buttons: https://design-system.service.gov.uk/components/button/
 
-======
+######
 Button
-======
+######
 A `Button`_ component is all you need to submit a form: ::
 
     from django import forms

--- a/docs/components/checkboxes.rst
+++ b/docs/components/checkboxes.rst
@@ -1,8 +1,8 @@
 .. _Checkboxes: https://design-system.service.gov.uk/components/checkboxes/
 
-==========
+##########
 Checkboxes
-==========
+##########
 A `Checkboxes`_ component is used to render multiple ChoiceField and BooleanField
 though you need to override the default widget used by Django on the form. ::
 

--- a/docs/components/details.rst
+++ b/docs/components/details.rst
@@ -1,8 +1,8 @@
 .. _Details: https://design-system.service.gov.uk/components/details/
 
-=======
+#######
 Details
-=======
+#######
 A `Details`_ component is simply HTML. It's included as a form component as details
 section are useful for adding extra, optional information such as help text to
 fields. ::

--- a/docs/components/fieldset.rst
+++ b/docs/components/fieldset.rst
@@ -1,8 +1,8 @@
 .. _Fieldset: https://design-system.service.gov.uk/components/fieldset/
 
-========
+########
 Fieldset
-========
+########
 Use a `Fieldset`_  component to group related fields together. ::
 
     from django import forms

--- a/docs/components/file.rst
+++ b/docs/components/file.rst
@@ -1,8 +1,8 @@
 .. _File upload: https://design-system.service.gov.uk/components/file-upload/
 
-===========
+###########
 File upload
-===========
+###########
 A `File upload`_ component helps users select and upload a file. ::
 
     from django import forms

--- a/docs/components/index.rst
+++ b/docs/components/index.rst
@@ -1,6 +1,14 @@
+.. _Components: https://design-system.service.gov.uk/components
+
+=============
+Design System
+=============
+There is support for all the Design System `Components`_ that you might expect
+to encounter in a complex form with the exception of ``Date input`` which is on
+the to-do list.
 
 .. toctree::
-    :maxdepth: 1
+    :maxdepth: 2
 
     accordion
     button
@@ -17,3 +25,10 @@
     text
     textarea
     warning
+
+The remaining components in the Design System list: `Back link`, `Breadcrumbs`,
+`Footer`, `Header`, `Phase panel` and `Skip link` are page-level components and
+probably have limited utility within a form nd are not supported, as yet. However
+`Summary list` has the potential for being used in a form. We are just not sure
+how to implement it, given that the list contents and specifically actions can
+be laid out in various ways.

--- a/docs/components/inset.rst
+++ b/docs/components/inset.rst
@@ -1,8 +1,8 @@
 .. _Inset text: https://design-system.service.gov.uk/components/inset-text/
 
-==========
+##########
 Inset text
-==========
+##########
 An `Inset text`_ component is simply HTML. It's included as a form component
 so you can notes or side-comments to the body of a form. ::
 

--- a/docs/components/panel.rst
+++ b/docs/components/panel.rst
@@ -1,8 +1,8 @@
 .. _Panel: https://design-system.service.gov.uk/components/panel/
 
-=====
+#####
 Panel
-=====
+#####
 Use a `Panel`_ component for confirmation messages or to highlight important sections. ::
 
     from django import forms

--- a/docs/components/radios.rst
+++ b/docs/components/radios.rst
@@ -1,8 +1,8 @@
 .. _Radios: https://design-system.service.gov.uk/components/radios/
 
-======
+######
 Radios
-======
+######
 A `Radios`_ component is used when there is only one option allowed from a list. ::
 
     from django import forms

--- a/docs/components/select.rst
+++ b/docs/components/select.rst
@@ -1,8 +1,8 @@
 .. _Select: https://design-system.service.gov.uk/components/select/
 
-======
+######
 Select
-======
+######
 Use a `Select`_ component only as a last resort for public facing services as there is
 often a high rate of errors. ::
 

--- a/docs/components/tabs.rst
+++ b/docs/components/tabs.rst
@@ -1,8 +1,8 @@
 .. _Tabs: https://design-system.service.gov.uk/components/tabs/
 
-====
+####
 Tabs
-====
+####
 There are two Layout classes for adding an `Tabs`_ to a form. ``TabPanel``
 which wraps the contents of each section and ``Tabs`` which wraps the sections
 and adds the ability to step between them. ::

--- a/docs/components/tag.rst
+++ b/docs/components/tag.rst
@@ -1,8 +1,8 @@
 .. _Tag: https://design-system.service.gov.uk/components/tag/
 
-===
+###
 Tag
-===
+###
 A `Tag`_ is general used to report status. ::
 
     from django import forms

--- a/docs/components/text.rst
+++ b/docs/components/text.rst
@@ -1,8 +1,8 @@
 .. _Text input: https://design-system.service.gov.uk/components/text-input/
 
-==========
+##########
 Text input
-==========
+##########
 The `Text input`_ component is the work-horse of any form: ::
 
     from django import forms

--- a/docs/components/textarea.rst
+++ b/docs/components/textarea.rst
@@ -1,8 +1,8 @@
 .. _Textarea: https://design-system.service.gov.uk/components/textarea/
 
-========
+########
 Textarea
-========
+########
 Adding a `Textarea`_ to a form is straightforward: ::
 
     from django import forms

--- a/docs/components/warning.rst
+++ b/docs/components/warning.rst
@@ -1,8 +1,8 @@
 .. _Warning text: https://design-system.service.gov.uk/components/warning-text/
 
-============
+############
 Warning text
-============
+############
 A `Warning text`_ component is simply HTML. It's included as a form component as
 warnings are useful for frightening your users into filling out the form
 correctly. ::

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,10 +10,16 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
+import os
+import sys
 
-# sys.path.insert(0, os.path.abspath('.'))
+import django
+
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.abspath(os.path.join(ROOT_DIR, 'src', 'crispy_forms_gds')))
+
+os.environ['DJANGO_SETTINGS_MODULE'] = 'docs.settings'
+django.setup()
 
 # -- Project information -----------------------------------------------------
 
@@ -37,6 +43,7 @@ release = "0.0.1"
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -50,7 +57,6 @@ master_doc = 'index'
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
-
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -62,3 +68,7 @@ html_theme = 'sphinx_rtd_theme'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+html_css_files = [
+    'css/gds.css',
+]

--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -1,0 +1,15 @@
+.. Color profiles and font sizes for the Design System.
+.. Intended to be used with _static/css/gds.css
+.. role:: tag-blue
+.. role:: tag-green
+.. role:: tag-grey
+.. role:: tag-orange
+.. role:: tag-pink
+.. role:: tag-purple
+.. role:: tag-red
+.. role:: tag-turquoise
+.. role:: tag-yellow
+.. role:: font-small
+.. role:: font-medium
+.. role:: font-large
+.. role:: font-extra-large

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,10 +17,23 @@ for the `GOV.UK Design System`_.
     start/index
 
 .. toctree::
-    :caption: Layouts: Components
-    :maxdepth: 1
+    :caption: Components
+    :maxdepth: 2
 
     components/index
+
+.. toctree::
+    :caption: Classes
+    :maxdepth: 2
+
+    classes/templatetags
+    classes/helper
+    classes/constants
+    classes/fields
+    classes/buttons
+    classes/containers
+    classes/content
+
 
 .. _CHANGELOG: https://github.com/wildfish/crispy-forms-gds/blob/master/CHANGELOG.md
 

--- a/docs/settings.py
+++ b/docs/settings.py
@@ -1,0 +1,28 @@
+"""
+MVS (Minimalist Viable Settings) for running the tests.
+
+"""
+
+SECRET_KEY = "secret"
+
+INSTALLED_APPS = (
+    "crispy_forms",
+    "crispy_forms_gds",
+)
+
+ROOT_URLCONF = "tests.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {},
+    },
+]
+
+CRISPY_ALLOWED_TEMPLATE_PACKS = ("gds",)
+
+CRISPY_TEMPLATE_PACK = "gds"
+
+CRISPY_FAIL_SILENTLY = False

--- a/docs/start/example.rst
+++ b/docs/start/example.rst
@@ -1,0 +1,52 @@
+.. _Components: https://design-system.service.gov.uk/components
+.. _Error summary: https://design-system.service.gov.uk/components/error-summary/
+
+=======
+Example
+=======
+You use crispy-forms-gds just like a regular crispy form. The minimum viable form
+using this template pack is something like this: ::
+
+    from django import forms
+
+    from crispy_forms_gds.helper import FormHelper
+    from crispy_forms_gds.layout import Submit
+
+
+    class MinimumForm(forms.Form):
+
+        name = forms.CharField(
+            label="Name",
+            help_text="Your full name.",
+            error_messages={
+                "required": "Enter your name as it appears on your passport"
+            }
+        )
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.helper = FormHelper(self)
+            self.helper.add_input(Submit("submit", _("Submit")))
+
+All that is needed is to add the ``FormHelper`` class to the Form. Then in your
+template add Design System `Error summary`_ and the ``crispy`` templatetag: ::
+
+    {% load i18n crispy_forms_tags %}
+    ...
+    {% if form.helper.form_show_errors and form.errors %}
+      {% include 'gds/layout/error_summary.html' %}
+    {% endif %}
+    ...
+    {% crispy form %}
+    ...
+
+[That's way too much typing so if possible, we will look at replacing that conditional
+with another templatetag, for example ``{% error_summary form %}``.]
+
+The template pack takes care of all the rendering so the code above is displayed as:
+
+.. image:: form.png
+
+That's pretty basic but that's all you need to display forms that meet all the
+requirements for presentation and accessibility, recommended and mandated by the
+Design System guidelines.

--- a/docs/start/index.rst
+++ b/docs/start/index.rst
@@ -4,4 +4,5 @@
     install
     settings
     demo
-    examples
+    example
+    layouts

--- a/docs/start/layouts.rst
+++ b/docs/start/layouts.rst
@@ -1,66 +1,51 @@
-.. _Components: https://design-system.service.gov.uk/components
-.. _Error summary: https://design-system.service.gov.uk/components/error-summary/
+=======
+Layouts
+=======
+The real power of the crispy way is the ability to define exactly how a form is
+laid out in code rather than in HTML. The GOV.UK Design System adds a lot of attributes
+and CSS classes to the basic HTML tags that make up a form. When you add all the
+attributes needed for accessibility to ensure your forms are usable by as wide a
+range of people as possible then the resultant HTML is hard to manage: ::
 
-========
-Examples
-========
-You use crispy-forms-gds just like a regular crispy form except you import
-the various objects from ``crispy_forms_gds`` instead of crispy_forms. The
-minimum viable form using this template pack is: ::
+    <div id="div_id_name" class="govuk-form-group">
+      <label for="id_name" class="govuk-label">
+        Name
+      </label>
+      <div id="id_name_hint" class="govuk-hint">
+        Help text
+      </div>
+      <input type="text" name="name"
+             aria-describedby="id_name_hint"
+             class="govuk-input"
+             id="id_name">
+    </div>
 
-    from django import forms
+Now add in the markup needed to display an error: ::
 
-    from crispy_forms_gds.helper import FormHelper
-    from crispy_forms_gds.layout import Submit
+    <div id="div_id_name" class="govuk-form-group govuk-form-group--error">
+      <label for="id_name" class="govuk-label">
+        Name
+      </label>
+      <div id="id_name_hint" class="govuk-hint">
+        Help text
+      </div>
+      <span id="id_name_1_error" class="govuk-error-message">
+        <span class="govuk-visually-hidden">Error:</span> Required error message
+      </span>
+      <input type="text" name="name"
+             aria-describedby="id_name_hint id_name_1_error"
+             class="govuk-input govuk-input--error"
+             id="id_name">
+    </div>
 
+That's the absolute bare minimum needed to render a single text field and there's
+no support for the error summary, autocomplete or other attributes to make the form
+accessible. It's a lot of work and it's very easy to leave off a single attribute
+that would render the form useless for people with screen readers, for example.
 
-    class MinimumForm(forms.Form):
-
-        name = forms.CharField(
-            label="Name",
-            help_text="Your full name.",
-            error_messages={
-                "required": "Enter your name as it appears on your passport"
-            }
-        )
-
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            self.helper = FormHelper(self)
-            self.helper.add_input(Submit("submit", _("Submit")))
-
-All that is needed is to add the ``FormHelper`` class to the Form. Then in your
-template add Design System `Error summary`_ and the ``crispy`` templatetag: ::
-
-    {% load i18n crispy_forms_tags %}
-    ...
-    {% if form.helper.form_show_errors and form.errors %}
-      {% include 'gds/layout/error_summary.html' %}
-    {% endif %}
-    ...
-    {% crispy form %}
-    ...
-
-The template pack takes care of all the rendering so the displayed form follows
-the Design System style and takes care of accessibility as well.
-
-.. image:: form.png
-
-There is support for all the Design System `Components`_ that you might expect
-to encounter in a complex form with the exception of ``Date input`` which is on
-the to-do list. There are some components like ``Summary list``, ``Table`` and
-possibly, ``Skip link`` which might be useful but are not implemented currently
-as they are probably rarely needed. The rest: ``Back link``, ``Breadcrumbs``,
-``Header``, ``Footer`` and ``Phase banner`` are unlikely to ever appear in a form.
-
-Many of the Design System Components can be configured, for example setting the
-size of a label or the width of a text field. The simplest way is the crispy
-way and use ``Layout`` objects to pass in the necessary parameters. Some of the
-configuration involves setting CSS classes as well as template variables so
-``crispy-forms-gds`` adds a set of class methods to the various layout objects
-to make that easier. The following form is a big of a dog's breakfast in terms
-of user experience but it does give you a good overview of just how little code
-you need to create quite complex forms: ::
+Layouts solve all these problems. The template pack supports all the components
+available in the Design System so you can quickly and easily lay out a form and
+any incidental content with a minimum of effort: ::
 
     from django import forms
 
@@ -166,3 +151,38 @@ you need to create quite complex forms: ::
                 ),
                 Button.primary("apply", "Apply"),
             )
+
+That's a slightly contrived example but it shows you how the various Design
+System components can be used and configured in code.
+
+Take a look at the source code for the Demo Site. There's the base template
+for laying out the page but the main ``{% block %}`` for the page contents
+is just: ::
+
+    {% extends "components/base.html" %}
+    {% load i18n crispy_forms_tags %}
+
+    {% block content %}
+
+      {% if form.helper.form_show_errors and form.errors %}
+        {% include 'gds/layout/error_summary.html' %}
+      {% endif %}
+
+      <span class="govuk-caption-xl">
+        {% trans 'Components' %}
+      </span>
+      <h1 class="govuk-heading-xl">
+        {{ title }}
+      </h1>
+
+      <div class="govuk-body">
+        {% crispy form %}
+      </div>
+
+    {% endblock %}
+
+That's all the markup needed to display any of the forms in the Demo Site.
+All the work is done in the form layouts. All the markup for accessibility
+is already included in the template pack. You get 100% compliant forms, 100%
+of the time. When that is replicated across all the projects that use the
+GOV.UK Design System the savings in time and effort should be substantial.

--- a/docs/urls.py
+++ b/docs/urls.py
@@ -1,0 +1,3 @@
+# A minimal Django setup requires urlpatterns to be defined but it
+# can happily be empty.
+urlpatterns = []

--- a/src/crispy_forms_gds/helper.py
+++ b/src/crispy_forms_gds/helper.py
@@ -4,40 +4,75 @@ from crispy_forms.utils import TEMPLATE_PACK
 
 class FormHelper(crispy_forms_helper.FormHelper):
     """
+    .. _FormHelper: https://django-crispy-forms.readthedocs.io/en/latest/form_helper.html
+
     This class controls the form rendering behavior of the form passed to
-    the `{% crispy %}` tag. It intended to be use exclusively with the 'gds'
-    template pack and adds the following attributes to control how the form
-    is rendered:
+    the ``{% crispy %}`` tag. It intended to be use exclusively with the 'gds'
+    template pack and extends the django-crispy-forms `FormHelper`_ class by
+    adding the following attributes to control how the form is rendered.
 
-        **form_show_non_field_errors**: control whether non-field errors are
-            displayed at the top of the form. The default is False as it assumes
-            an Error summary will be displayed at the top of the page.
+    Attributes:
+        show_non_field_errors (bool): display non-field errors at the top of
+            the form. The default is ``False`` as the Design System mandates
+            that all form errors are displayed in an Error Summary at the top
+            of the page (above the page title and outside the <form>). Only
+            set this to ``True`` if you are not using an Error Summary.
 
-        **form_show_required_attribute**: control whether a required attribute
-            is displayed when a widget is rendered. The default is not to show
-            the attribute as it triggers the browser to interfere with the way
-            field errors are shown.
+        label_size (:obj:`str`, optional): set the default size used for all
+            field labels. The default value of None renders labels with the
+            same font size as body text. To change the font size and weight
+            use one of the pre-defined Design System sizes: 's', 'm', 'l'
+            or 'xl'.
 
-        **label_size**: if not None, make labels bold and larger than the
-            default. Values can be 's', 'm', 'l' and 'xl'.
+        legend_size (:obj:`str`, optional): set the default size used for
+            fields that use <legend> instead of <label> (checkboxes and radios).
+            The default value of None renders labels with the same font size
+            as body text. To change the font size and weight use one of the
+            pre-defined Design System sizes: 's', 'm', 'l' or 'xl'.
 
-        **legend_size**: if not None, make legends bold and larger than the
-            default. Values can be 's', 'm', 'l' and 'xl'. Generally this will
-            be the same size set for labels.
+
+    Examples:
+        You use FormHelper the same way as the django-crispy-form version.
+
+        Let the FormHelper create a default layout for the form: ::
+
+            def __init__(self, *args, **kwargs):
+                super(MyForm, self).__init__(*args, **kwargs)
+                self.helper = FormHelper(form)
+
+        Create a custom Layout: ::
+
+            def __init__(self, *args, **kwargs):
+                super(MyForm, self).__init__(*args, **kwargs)
+                self.helper = FormHelper()
+                self.helper.layout = Layout(
+                   ...
+                )
+
+    All the existing `FormHelper`_ methods are available if you need something
+    specific.
+
     """
 
-    form_show_non_field_errors = False
-    form_show_required_attribute = False
+    show_non_field_errors = False
     label_size = ""
     legend_size = ""
 
     def render_layout(self, form, context, template_pack=TEMPLATE_PACK):
         """
-        Returns safe html of the rendering of the layout
+        Returns safe html of the rendering of the layout.
+
+        :meta private:
         """
-        form.use_required_attribute = self.form_show_required_attribute
+        # Django will add a required attribute when a field is rendered, if is
+        # required by the form. The browser validation interferes with the way
+        # validation errors are reported so adding required attributes is
+        # disabled at the form level.
+        form.use_required_attribute = False
+
         if self.label_size:
             context["label_size"] = self.label_size
         if self.legend_size:
             context["legend_size"] = self.legend_size
+
         return super().render_layout(form, context, template_pack=template_pack)

--- a/src/crispy_forms_gds/layout/__init__.py
+++ b/src/crispy_forms_gds/layout/__init__.py
@@ -1,8 +1,9 @@
-from .base import Div, Layout
+from .base import Layout
 from .buttons import Button, Submit
-from .containers import Accordion, AccordionSection, Fieldset, TabPanel, Tabs
+from .constants import Fixed, Fluid, Size
+from .containers import Accordion, AccordionSection, Div, Fieldset, TabPanel, Tabs
 from .content import HTML, Colour
-from .fields import Field, Fixed, Fluid, Hidden, Size
+from .fields import Field, Hidden
 
 
 __all__ = [

--- a/src/crispy_forms_gds/layout/base.py
+++ b/src/crispy_forms_gds/layout/base.py
@@ -3,7 +3,3 @@ from crispy_forms import layout as crispy_forms_layout
 
 class Layout(crispy_forms_layout.Layout):
     pass
-
-
-class Div(crispy_forms_layout.Div):
-    pass

--- a/src/crispy_forms_gds/layout/buttons.py
+++ b/src/crispy_forms_gds/layout/buttons.py
@@ -1,19 +1,6 @@
 from crispy_forms.layout import BaseInput
 
 
-class Submit(BaseInput):
-    """
-    Used to create a Submit button descriptor for the {% crispy %} template tag::
-
-        submit = Submit('Search the Site', 'search this site')
-
-    .. note:: The first argument is also slugified and turned into the id for the submit button.
-    """
-
-    input_type = "submit"
-    field_classes = "govuk-button"
-
-
 class Button(BaseInput):
     """
     Create a button of any type. ::
@@ -78,3 +65,16 @@ class Button(BaseInput):
             kwargs["aria-disabled"] = "true"
 
         super().__init__(name, value, data_module="govuk-button", **kwargs)
+
+
+class Submit(BaseInput):
+    """
+    Used to create a Submit button descriptor for the {% crispy %} template tag::
+
+        submit = Submit('Search the Site', 'search this site')
+
+    .. note:: The first argument is also slugified and turned into the id for the submit button.
+    """
+
+    input_type = "submit"
+    field_classes = "govuk-button"

--- a/src/crispy_forms_gds/layout/constants.py
+++ b/src/crispy_forms_gds/layout/constants.py
@@ -1,0 +1,311 @@
+class Colour:
+    """
+    .. include:: ../conf.rst
+
+    A set of constants for defining tag colours.
+
+    Attributes:
+        BLUE: Make the tag :tag-blue:`BLUE`.
+        GREEN: Make the tag :tag-green:`GREEN`.
+        GREY: Make the tag :tag-grey:`GREY`.
+        ORANGE: Make the tag :tag-orange:`ORANGE`.
+        PINK: Make the tag :tag-pink:`PINK`.
+        PURPLE: Make the tag :tag-purple:`PURPLE`.
+        RED: Make the tag :tag-red:`RED`.
+        TURQUOISE: Make the tag :tag-turquoise:`TURQUOISE`.
+        YELLOW: Make the tag :tag-yellow:`YELLOW`.
+
+    Examples:
+        You pass the colour in the class method for generating a tag: ::
+
+            HTML.tag("Pending", Colour.BLUE)
+
+        If a new class is added but is has not been added to the template
+        pack, then just pass the name: ::
+
+            HTML.tag("Pending", 'lilac', validate=False)
+
+    """
+
+    # Don't define the attribute here as you'll be forced to add the
+    # type which makes the documentation a lot less readable
+
+    BLUE = "blue"
+    GREEN = "green"
+    GREY = "grey"
+    ORANGE = "orange"
+    PINK = "pink"
+    PURPLE = "purple"
+    RED = "red"
+    TURQUOISE = "turquoise"
+    YELLOW = "yellow"
+
+    _values = (BLUE, GREEN, GREY, ORANGE, PINK, PURPLE, RED, TURQUOISE, YELLOW)
+
+    @classmethod
+    def is_valid(cls, value):
+        """Check whether a value is one of the pre-defined colours.
+
+        Args:
+            value (str): the name of the colour.
+
+        Returns:
+            True if the value equals one of the constants, False otherwise.
+
+        """
+        return value in cls._values
+
+    @classmethod
+    def for_tag(cls, value, validate=True):
+        """
+        Convert the colour name into a CSS class that can be added to a Tag
+        component.
+
+        Args:
+            value: the colour.
+            validate: check whether the colour is one of the pre-defined
+                values. Defaults to True.
+
+        Raises:
+            ValueError: if validate is True and the colour is invalid.
+
+        Returns:
+            str: the CSS class used to set the tag colour.
+
+        """
+        if validate and not cls.is_valid(value):
+            raise ValueError("Unexpected colour", value)
+        return "govuk-tag--%s" % value
+
+
+class Size:
+    """
+    .. include:: ../conf.rst
+
+    A set of constants for setting the size of labels, legends or headings.
+
+    Attributes:
+        SMALL: :font-small:`SMALL`.
+        MEDIUM: :font-medium:`MEDIUM`.
+        LARGE: :font-large:`LARGE`.
+        EXTRA_LARGE: :font-extra-large:`EXTRA LARGE`.
+
+    Examples:
+        Set the label size and heading level for a Text input (remember
+        the heading level is the semantic level and not the size): ::
+
+            Field.text("name", label_size=Size.SMALL, label_tag="h2")
+
+        Set the legend size for a set of checkboxes: ::
+
+            Field.checkboxes("multiple", legend_size=Size.MEDIUM)
+
+
+    """
+
+    # Don't define the attribute here as you'll be forced to add the
+    # type which makes the documentation a lot less readable
+
+    SMALL = "s"
+    MEDIUM = "m"
+    LARGE = "l"
+    EXTRA_LARGE = "xl"
+
+    _values = (SMALL, MEDIUM, LARGE, EXTRA_LARGE)
+
+    @classmethod
+    def is_valid(cls, value):
+        """Check whether a value is one of the pre-defined sizes.
+
+        Args:
+            value (str): the size.
+
+        Returns:
+            True if the value equals one of the constants, False otherwise.
+
+        """
+        return value in cls._values
+
+    @classmethod
+    def for_label(cls, value, validate=True):
+        """
+        Convert the constant into a CSS class that can be used with a <label>.
+
+        Args:
+            value: the size.
+            validate: check whether the size is one of the predefined
+                values. Defaults to True.
+
+        Raises:
+            ValueError: if validate is True and the size in invalid.
+
+        Returns:
+            str: the CSS class used to set the font size for a label heading.
+
+        """
+        if validate and not cls.is_valid(value):
+            raise ValueError("Unexpected size", value)
+        return "govuk-label--%s" % value
+
+    @classmethod
+    def for_legend(cls, value, validate=True):
+        """
+        Convert the constant into a CSS class that can be used with a <legend>.
+
+        Args:
+            value: the size.
+            validate: check whether the size is one of the pre-defined
+                values. Defaults to True.
+
+        Raises:
+            ValueError: if validate is True and the size is invalid.
+
+        Returns:
+            str: the CSS class used to set the font size for a legend.
+
+        """
+        if validate and not cls.is_valid(value):
+            raise ValueError("Unexpected size", value)
+        return "govuk-fieldset__legend--%s" % value
+
+
+class Fixed:
+    """
+    A set of constants for setting the width of a Text inputs to a fixed
+    number of characters.
+
+    Attributes:
+        TWO: Set the Text input to be 2 characters wide.
+        THREE: Set the Text input to be 3 characters wide.
+        FOUR: Set the Text input to be 4 characters wide.
+        FIVE: Set the Text input to be 5 characters wide.
+        TEN: Set the Text input to be 10 characters wide.
+        TWENTY: Set the Text input to be 20 characters wide.
+        THIRTY: Set the Text input to be 30 characters wide.
+
+    Examples:
+        ::
+
+            Field.text("phone", field_width=Fixed.TWENTY)
+            Field.text("age", css_class=Fixed.for_input)
+
+    """
+
+    # Don't define the attribute here as you'll be forced to add the
+    # type which makes the documentation a lot less readable
+
+    TWO = 2
+    THREE = 3
+    FOUR = 4
+    FIVE = 5
+    TEN = 10
+    TWENTY = 20
+    THIRTY = 30
+
+    _values = (TWO, THREE, FOUR, FIVE, TEN, TWENTY, THIRTY)
+
+    @classmethod
+    def is_valid(cls, value):
+        """Check whether a value is one of the pre-defined values.
+
+        Args:
+            value: the width.
+
+        Returns:
+            True if the value equals one of the fixed widths, False otherwise.
+
+        """
+        return value in cls._values
+
+    @classmethod
+    def for_input(cls, value, validate=True):
+        """
+        Convert the fixed width into a CSS class.
+
+        Args:
+            value: the width.
+            validate: check whether the width is a fixed value.
+
+        Raises:
+            ValueError: if validate is True and the value is invalid.
+
+        Returns:
+            str: the CSS class used to set the width of a Text input.
+
+        """
+        if validate and not cls.is_valid(value):
+            raise ValueError("Unexpected fixed width", value)
+        return "govuk-input--width-%d" % value
+
+
+class Fluid:
+    """
+    A set of constants for setting a fluid width on Text inputs.
+
+    Attributes:
+        ONE_QUARTER: Set the Text input to be 25% of the width of the parent.
+        ONE_THIRD: Set the Text input to be 33% of the width of the parent.
+        ONE_HALF: Set the Text input to be 50% of the width of the parent.
+        TWO_THIRDS: Set the Text input to be 66% of the width of the parent.
+        THREE_QUARTERS: Set the Text input to be 75% of the width of the parent.
+        FULL: Set the Text input to be 100% of the width of the parent.
+
+    Examples:
+        ::
+
+            Field.text("name", field_width=Fluid.TWO_THIRDS),
+            Field.text("email", css_class=Fluid.for_input('one-fifth', validate=False)),
+
+    """
+
+    # Don't define the attribute here as you'll be forced to add the
+    # type which makes the documentation a lot less readable
+
+    ONE_QUARTER = "one-quarter"
+    ONE_THIRD = "one-third"
+    ONE_HALF = "one-half"
+    TWO_THIRDS = "two-thirds"
+    THREE_QUARTERS = "three-quarters"
+    FULL = "full"
+
+    _values = (
+        ONE_QUARTER,
+        ONE_THIRD,
+        ONE_HALF,
+        TWO_THIRDS,
+        THREE_QUARTERS,
+        FULL,
+    )
+
+    @classmethod
+    def is_valid(cls, value):
+        """Check whether a value is one of the pre-defined values.
+
+        Args:
+            value: the width.
+
+        Returns:
+            True if the value equals one of the fixed widths, False otherwise.
+
+        """
+        return value in cls._values
+
+    @classmethod
+    def for_input(cls, value, validate=True):
+        """
+        Convert the fluid width into a CSS class.
+
+        Args:
+            value: the width.
+            validate: check whether the width is a fluid value.
+
+        Raises:
+            ValueError: if validate is True and the width is not fluid.
+
+        Returns:
+            str: the CSS class used to set the width of a Text input.
+
+        """
+        if validate and not cls.is_valid(value):
+            raise ValueError("Unexpected fluid width", value)
+        return "govuk-!-width-%s" % value

--- a/src/crispy_forms_gds/layout/containers.py
+++ b/src/crispy_forms_gds/layout/containers.py
@@ -3,7 +3,74 @@ from django.utils.text import slugify
 
 from crispy_forms import layout as crispy_forms_layout
 from crispy_forms.utils import TEMPLATE_PACK, flatatt, render_field
-from crispy_forms_gds.layout import Div
+
+
+class Div(crispy_forms_layout.Div):
+    pass
+
+
+class Accordion(Div):
+    """
+    Accordion menu object. It wraps `AccordionSection` objects in a container::
+
+        Accordion(
+            AccordionSection("group name", "form_field_1", "form_field_2"),
+            AccordionSection("another group name", "form_field")
+        )
+    """
+
+    template = "%s/accordion.html"
+
+    def __init__(self, *fields, **kwargs):
+        super().__init__(*fields, **kwargs)
+        self.fields = list(fields)
+
+        if hasattr(self, "css_class") and "css_class" in kwargs:
+            self.css_class += " %s" % kwargs.pop("css_class")
+        if not hasattr(self, "css_class"):
+            self.css_class = kwargs.pop("css_class", None)
+
+        self.css_id = kwargs.pop("css_id", "")
+        self.template = kwargs.pop("template", self.template)
+        self.flat_attrs = flatatt(kwargs)
+
+    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
+        content = ""
+        for group in self.fields:
+            content += render_field(
+                group, form, form_style, context, template_pack=template_pack, **kwargs
+            )
+        template = self.get_template_name(template_pack)
+        context.update({"accordion": self, "content": content})
+        return render_to_string(template, context.flatten())
+
+
+class AccordionSection(Div):
+    """
+    Accordion Section (pane) object. It wraps given fields inside an accordion
+    tab. It takes accordion tab name as first argument::
+
+        AccordionSection("section_name", "form_field_1", "form_field_2")
+    """
+
+    template = "%s/accordion-group.html"
+    data_parent = ""  # accordion parent div id.
+    css_class = ""
+
+    def __init__(self, name, *fields, **kwargs):
+        super().__init__(*fields, **kwargs)
+        self.name = name
+        if not self.css_id:
+            self.css_id = slugify(self.name)
+
+    def __contains__(self, field_name):
+        """
+        check if field_name is contained within tab.
+        """
+        return field_name in map(lambda pointer: pointer[1], self.get_field_names())
+
+    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
+        return super().render(form, form_style, context, template_pack)
 
 
 class Fieldset(crispy_forms_layout.LayoutObject):
@@ -49,29 +116,6 @@ class Fieldset(crispy_forms_layout.LayoutObject):
         return render_to_string(template, context)
 
 
-class TabPanel(Div):
-    """
-    A layout object that displays the contents of each pane in a set of tabs.
-
-    Example::
-
-        TabPanel('tab_name', 'form_field_1', 'form_field_2', 'form_field_3')
-    """
-
-    css_class = "govuk-tabs__panel"
-    link_template = "%s/layout/tab-link.html"
-
-    def __init__(self, name, *fields, **kwargs):
-        super().__init__(*fields, **kwargs)
-        self.name = name
-        if not self.css_id:
-            self.css_id = slugify(self.name)
-
-    def render_link(self, template_pack=TEMPLATE_PACK):
-        link_template = self.link_template % template_pack
-        return render_to_string(link_template, {"link": self})
-
-
 class Tabs(Div):
     """
     A layout object for displaying a set of tabs.
@@ -94,17 +138,17 @@ class Tabs(Div):
         return render_to_string(template, context.flatten())
 
 
-class AccordionSection(Div):
+class TabPanel(Div):
     """
-    Accordion Section (pane) object. It wraps given fields inside an accordion
-    tab. It takes accordion tab name as first argument::
+    A layout object that displays the contents of each pane in a set of tabs.
 
-        AccordionSection("section_name", "form_field_1", "form_field_2")
+    Example::
+
+        TabPanel('tab_name', 'form_field_1', 'form_field_2', 'form_field_3')
     """
 
-    template = "%s/accordion-group.html"
-    data_parent = ""  # accordion parent div id.
-    css_class = ""
+    css_class = "govuk-tabs__panel"
+    link_template = "%s/layout/tab-link.html"
 
     def __init__(self, name, *fields, **kwargs):
         super().__init__(*fields, **kwargs)
@@ -112,47 +156,6 @@ class AccordionSection(Div):
         if not self.css_id:
             self.css_id = slugify(self.name)
 
-    def __contains__(self, field_name):
-        """
-        check if field_name is contained within tab.
-        """
-        return field_name in map(lambda pointer: pointer[1], self.get_field_names())
-
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
-        return super().render(form, form_style, context, template_pack)
-
-
-class Accordion(Div):
-    """
-    Accordion menu object. It wraps `AccordionSection` objects in a container::
-
-        Accordion(
-            AccordionSection("group name", "form_field_1", "form_field_2"),
-            AccordionSection("another group name", "form_field")
-        )
-    """
-
-    template = "%s/accordion.html"
-
-    def __init__(self, *fields, **kwargs):
-        super().__init__(*fields, **kwargs)
-        self.fields = list(fields)
-
-        if hasattr(self, "css_class") and "css_class" in kwargs:
-            self.css_class += " %s" % kwargs.pop("css_class")
-        if not hasattr(self, "css_class"):
-            self.css_class = kwargs.pop("css_class", None)
-
-        self.css_id = kwargs.pop("css_id", "")
-        self.template = kwargs.pop("template", self.template)
-        self.flat_attrs = flatatt(kwargs)
-
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
-        content = ""
-        for group in self.fields:
-            content += render_field(
-                group, form, form_style, context, template_pack=template_pack, **kwargs
-            )
-        template = self.get_template_name(template_pack)
-        context.update({"accordion": self, "content": content})
-        return render_to_string(template, context.flatten())
+    def render_link(self, template_pack=TEMPLATE_PACK):
+        link_template = self.link_template % template_pack
+        return render_to_string(link_template, {"link": self})

--- a/src/crispy_forms_gds/layout/content.py
+++ b/src/crispy_forms_gds/layout/content.py
@@ -2,39 +2,69 @@ from django.template import Context, Template
 from django.utils.safestring import mark_safe
 
 from crispy_forms import layout as crispy_forms_layout
-
-
-class Colour:
-    """
-    A set of constants for defining tag colours.
-    """
-
-    BLUE = "blue"
-    GREEN = "green"
-    GREY = "grey"
-    ORANGE = "orange"
-    PINK = "pink"
-    PURPLE = "purple"
-    RED = "red"
-    TURQUOISE = "turquoise"
-    YELLOW = "yellow"
-
-    _values = (BLUE, GREEN, GREY, ORANGE, PINK, PURPLE, RED, TURQUOISE, YELLOW)
-
-    @classmethod
-    def is_valid(cls, value):
-        return value in cls._values
-
-    @classmethod
-    def clean(cls, value):
-        if not cls.is_valid(value):
-            raise ValueError("Unexpected colour", value)
-        return "govuk-tag--" + value
+from crispy_forms_gds.layout.constants import Colour
 
 
 class HTML(crispy_forms_layout.HTML):
+    """
+    The HTML layout object lets you add general content to you form
+    so you can avoid having to lay it out manually.
+
+    You can pass in any string containing HTML: ::
+
+        self.helper.layout = Layout(
+            ...
+            HTML("<p>This is the content for a paragraph.</p>"),
+            ...
+        )
+
+    Alternatively, use one the class methods: ::
+
+         self.helper.layout = Layout(
+            ...
+            HTML.p("This is the content for a paragraph."),
+            ...
+        )
+
+    For something as simple a paragraph that does not save you much in
+    typing. However where it really makes a difference is when layout
+    complex things like tables which require a whole slew of classes to
+    be added to the basic HTML: ::
+
+        def __init__(self, *args, **kwargs):
+            super(MyForm, self).__init__(*args, **kwargs)
+
+            headings = ["Case manager", "Cases opened", "Cases closed"]
+
+            data = [
+                ["David Francis", "3", "0"],
+                ["Paul Farmer", "1", "0"],
+                ["Rita Patel", "2", "0"],
+            ]
+
+            self.helper = FormHelper()
+            self.helper.layout = Layout(
+                HTML.table(headings, data)
+            )
+
+
+    """
+
     @classmethod
     def details(cls, title, content):
+        """
+        .. _Details: https://design-system.service.gov.uk/components/details/
+
+        Generate the layout for a `Details`_ component.
+
+        Args:
+            title: the text for the short link.
+            content: the detailed description shown when the user clicks on the link.
+
+        Returns:
+            An HTML instance that can be added to a form's layout.
+
+        """
         snippet = """
             <details class="govuk-details" data-module="govuk-details">
               <summary class="govuk-details__summary">
@@ -55,32 +85,107 @@ class HTML(crispy_forms_layout.HTML):
 
     @classmethod
     def h1(cls, content):
+        """
+        Generate the HTML for a level one, ``<h1>``, heading.
+
+        Args:
+            content: the text for the heading.
+
+        Returns:
+            An HTML instance that can be added to a form's layout.
+
+        """
         return HTML.heading("h1", "xl", content)
 
     @classmethod
     def h2(cls, content):
+        """
+        Generate the HTML for a level two, ``<h2>``, heading.
+
+        Args:
+            content: the text for the heading.
+
+        Returns:
+            An HTML instance that can be added to a form's layout.
+
+        """
         return HTML.heading("h2", "l", content)
 
     @classmethod
     def h3(cls, content):
+        """
+        Generate the HTML for a level three, ``<h4>``, heading.
+
+        Args:
+            content: the text for the heading.
+
+        Returns:
+            An HTML instance that can be added to a form's layout.
+
+        """
         return HTML.heading("h3", "m", content)
 
     @classmethod
-    def h3(cls, content):
+    def h4(cls, content):
+        """
+        Generate the HTML for a level four, ``<h4>``, heading.
+
+        Args:
+            content: the text for the heading.
+
+        Returns:
+            An HTML instance that can be added to a form's layout.
+
+        """
         return HTML.heading("h4", "s", content)
 
     @classmethod
     def inset(cls, content):
+        """
+        .. _Inset text: https://design-system.service.gov.uk/components/inset-text/
+
+        Generate the layout for an `Inset text`_ component.
+
+        Args:
+            content: the text to be displayed.
+
+        Returns:
+            An HTML instance that can be added to a form's layout.
+
+        """
         snippet = '<div class="govuk-inset-text">%s</div>' % mark_safe(content)
         return HTML(snippet)
 
     @classmethod
     def p(cls, content):
+        """
+        Generate the HTML for a paragraph, ``<p>``.
+
+        Args:
+            content: the text to be displayed.
+
+        Returns:
+            An HTML instance that can be added to a form's layout.
+
+        """
         snippet = '<p class="govuk-body">%s</p>' % mark_safe(content)
         return HTML(snippet)
 
     @classmethod
     def panel(cls, title, content):
+        """
+        .. _Panel: https://design-system.service.gov.uk/components/panel/
+
+        Generate the layout for an `Panel`_ component.
+
+        Args:
+            title: the title.
+            content: the message (subtitle).
+
+        Returns:
+            An HTML instance that can be added to a form's layout.
+
+        """
         snippet = """
             <div class="govuk-panel govuk-panel--confirmation">
               <h1 class="govuk-panel__title">%s</h1>
@@ -94,6 +199,19 @@ class HTML(crispy_forms_layout.HTML):
 
     @classmethod
     def table(cls, headings, data):
+        """
+        .. _Table: https://design-system.service.gov.uk/components/table/
+
+        Generate the layout for an `Table`_ component.
+
+        Args:
+            headings: the list of heading for the columns.
+            data: the list of contents for each row - a list of lists of strings.
+
+        Returns:
+            An HTML instance that can be added to a form's layout.
+
+        """
         context = Context(dict(headings=headings, data=data))
         template = """
             <table class="govuk-table">
@@ -121,14 +239,43 @@ class HTML(crispy_forms_layout.HTML):
 
     @classmethod
     def tag(cls, title, colour):
+        """
+        .. _Tag: https://design-system.service.gov.uk/components/tag/
+
+        Generate the layout for an `Tag`_ component.
+
+        NOTE: the name of the colour is not validated so this method can still
+        be used if the Design System adds new colours not supported by the
+        template pack.
+
+        Args:
+            title: the text that is displayed in the tag.
+            colour: the name of the background colour used in the tag.
+
+        Returns:
+            An HTML instance that can be added to a form's layout.
+
+        """
         snippet = '<strong class="govuk-tag %s">%s</strong>' % (
-            Colour.clean(colour),
+            Colour.for_tag(colour, validate=False),
             mark_safe(title),
         )
         return HTML(snippet)
 
     @classmethod
     def warning(cls, content):
+        """
+        .. _Warning text: https://design-system.service.gov.uk/components/warning-text/
+
+        Generate the layout for an `Warning text`_ component.
+
+        Args:
+            content: the message that is displayed as a warning.
+
+        Returns:
+            An HTML instance that can be added to a form's layout.
+
+        """
         snippet = """
             <div class="govuk-warning-text">
               <span class="govuk-warning-text__icon" aria-hidden="true">!</span>

--- a/src/crispy_forms_gds/layout/fields.py
+++ b/src/crispy_forms_gds/layout/fields.py
@@ -2,87 +2,7 @@ from django.utils.html import conditional_escape
 
 from crispy_forms import layout as crispy_forms_layout
 from crispy_forms.utils import TEMPLATE_PACK
-
-
-class Size:
-    """
-    A set of constants for setting the size of labels, legends or headings.
-    """
-
-    SMALL = "s"
-    MEDIUM = "m"
-    LARGE = "l"
-    EXTRA_LARGE = "xl"
-
-    _values = (SMALL, MEDIUM, LARGE, EXTRA_LARGE)
-
-    @classmethod
-    def is_valid(cls, value):
-        return value in cls._values
-
-    @classmethod
-    def clean(cls, value):
-        if not cls.is_valid(value):
-            raise ValueError("Unexpected size", value)
-        return value
-
-
-class Fixed:
-    """
-    A set of constants for setting a fixed width on Text inputs.
-    """
-
-    TWO = 2
-    THREE = 3
-    FOUR = 4
-    FIVE = 5
-    TEN = 10
-    TWENTY = 20
-    THIRTY = 30
-
-    _values = (TWO, THREE, FOUR, FIVE, TEN, TWENTY, THIRTY)
-
-    @classmethod
-    def is_valid(cls, value):
-        return value in cls._values
-
-    @classmethod
-    def clean(cls, value):
-        if not cls.is_valid(value):
-            raise ValueError("Unexpected fixed width", value)
-        return "govuk-input--width-%d" % value
-
-
-class Fluid:
-    """
-    A set of constants for setting a fluid width on Text inputs.
-    """
-
-    ONE_QUARTER = "one-quarter"
-    ONE_THIRD = "one-third"
-    ONE_HALF = "one-half"
-    TWO_THIRDS = "two-thirds"
-    THREE_QUARTERS = "three-quarters"
-    FULL = "full"
-
-    _values = (
-        ONE_QUARTER,
-        ONE_THIRD,
-        ONE_HALF,
-        TWO_THIRDS,
-        THREE_QUARTERS,
-        FULL,
-    )
-
-    @classmethod
-    def is_valid(cls, value):
-        return value in cls._values
-
-    @classmethod
-    def clean(cls, value):
-        if not cls.is_valid(value):
-            raise ValueError("Unexpected fluid width", value)
-        return "govuk-!-width-%s" % value
+from crispy_forms_gds.layout import Fixed, Fluid, Size
 
 
 class Field(crispy_forms_layout.LayoutObject):
@@ -136,7 +56,7 @@ class Field(crispy_forms_layout.LayoutObject):
         context = {}
 
         if legend_size:
-            context["legend_size"] = Size.clean(legend_size)
+            context["legend_size"] = Size.for_legend(legend_size)
 
         if legend_tag:
             context["legend_tag"] = legend_tag
@@ -167,7 +87,38 @@ class Field(crispy_forms_layout.LayoutObject):
         context = {}
 
         if legend_size:
-            context["legend_size"] = Size.clean(legend_size)
+            context["legend_size"] = Size.for_legend(legend_size)
+
+        if legend_tag:
+            context["legend_tag"] = legend_tag
+
+        return Field(field, context=context, **kwargs)
+
+    @classmethod
+    def select(cls, field, legend_size=None, legend_tag=None, **kwargs):
+        """
+        Create a field for displaying a select drop-down.
+
+        Args:
+            field (str): the name of the field.
+
+            legend_size (str): the size of the legend. The default is None in which
+                case the legend will be rendered at the same size as regular text.
+
+            legend_tag (str): Wrap the field legend with this HTML tag.
+                Default is None.
+
+            **kwargs: Attributes to add to the <select> element when the field is
+                rendered.
+
+        Returns:
+            a Field object configured to display a Select component.
+
+        """
+        context = {}
+
+        if legend_size:
+            context["legend_size"] = Size.for_legend(legend_size)
 
         if legend_tag:
             context["legend_tag"] = legend_tag
@@ -198,20 +149,21 @@ class Field(crispy_forms_layout.LayoutObject):
             a Field object configured to display a Text input.
 
         """
-        css_class = None
         context = {}
 
         if label_size:
-            context["label_size"] = Size.clean(label_size)
+            context["label_size"] = Size.for_label(label_size)
 
         if label_tag:
             context["label_tag"] = label_tag
 
         if field_width:
             if isinstance(field_width, int):
-                css_class = Fixed.clean(field_width)
+                css_class = Fixed.for_input(field_width)
             else:
-                css_class = Fluid.clean(field_width)
+                css_class = Fluid.for_input(field_width)
+        else:
+            css_class = kwargs.get("css_class")
 
         return Field(field, css_class=css_class, context=context, **kwargs)
 
@@ -242,7 +194,7 @@ class Field(crispy_forms_layout.LayoutObject):
         context = {}
 
         if label_size:
-            context["label_size"] = Size.clean(label_size)
+            context["label_size"] = Size.for_label(label_size)
 
         if label_tag:
             context["label_tag"] = label_tag

--- a/src/crispy_forms_gds/templates/gds/display_form.html
+++ b/src/crispy_forms_gds/templates/gds/display_form.html
@@ -1,6 +1,6 @@
 {% if form.form_html %}
   {% if include_media %}{{ form.media }}{% endif %}
-  {% if form_show_errors and form.helper.form_show_non_field_errors %}
+  {% if form_show_errors and form.helper.show_non_field_errors %}
     {% include "gds/errors.html" %}
   {% endif %}
   {{ form.form_html }}

--- a/src/crispy_forms_gds/templates/gds/field.html
+++ b/src/crispy_forms_gds/templates/gds/field.html
@@ -17,7 +17,7 @@
 
       {% if field.label and not field|is_checkbox and form_show_labels %}
         {% if label_tag %}<{{ label_tag }} class="govuk-label-wrapper">{% endif %}
-        <label for="{{ field.id_for_label }}" class="govuk-label{% if label_size %} govuk-label--{{ label_size }}{% endif %}">
+        <label for="{{ field.id_for_label }}" class="govuk-label{% if label_size %} {{ label_size }}{% endif %}">
           {{ field.label|safe }}
         </label>
         {% if label_tag %}</{{ label_tag }}>{% endif %}

--- a/src/crispy_forms_gds/templates/gds/layout/checkboxes.html
+++ b/src/crispy_forms_gds/templates/gds/layout/checkboxes.html
@@ -2,7 +2,7 @@
 <fieldset class="govuk-fieldset"{% if field.help_text or field.errors %} aria-describedby="{% if field.help_text %}id_method_hint{% endif %}{% for error in field.errors %} {{ field.auto_id }}_{{ forloop.counter }}_error{% endfor %}"{% endif %}>
 
   {% if field.label %}
-    <legend class="govuk-fieldset__legend{% if legend_size %} govuk-fieldset__legend--{{ legend_size }}{% endif %}">
+    <legend class="govuk-fieldset__legend{% if legend_size %} {{ legend_size }}{% endif %}">
       {% if legend_tag %}<{{ legend_tag }} class="govuk-fieldset__heading">{% endif %}
       {{ field.label|safe }}
       {% if legend_tag %}</{{ legend_tag }}>{% endif %}

--- a/src/crispy_forms_gds/templates/gds/layout/fieldset.html
+++ b/src/crispy_forms_gds/templates/gds/layout/fieldset.html
@@ -2,7 +2,7 @@
     {% if fieldset.css_class or form_style %}class="{{ fieldset.css_class }} {{ form_style }}"{% endif %}
     {{ fieldset.flat_attrs|safe }}>
     {% if legend %}
-      <legend class="govuk-fieldset__legend{% if legend_size %} govuk-fieldset__legend--{{ legend_size }}{% endif %}">
+      <legend class="govuk-fieldset__legend{% if legend_size %} {{ legend_size }}{% endif %}">
       {% if legend_tag %}<{{ legend_tag }} class="govuk-fieldset__heading">{% endif %}
       {{ legend|safe }}
       {% if legend_tag %}</{{ legend_tag }}>{% endif %}

--- a/src/crispy_forms_gds/templates/gds/layout/radios.html
+++ b/src/crispy_forms_gds/templates/gds/layout/radios.html
@@ -2,7 +2,7 @@
 <fieldset class="govuk-fieldset"{% if field.help_text or field.errors %} aria-describedby="{% if field.help_text %}id_method_hint{% endif %}{% for error in field.errors %} {{ field.auto_id }}_{{ forloop.counter }}_error{% endfor %}"{% endif %}>
 
   {% if field.label %}
-    <legend class="govuk-fieldset__legend{% if legend_size %} govuk-fieldset__legend--{{ legend_size }}{% endif %}">
+    <legend class="govuk-fieldset__legend{% if legend_size %} {{ legend_size }}{% endif %}">
       {% if legend_tag %}<{{ legend_tag }} class="govuk-fieldset__heading">{% endif %}
       {{ field.label|safe }}
       {% if legend_tag %}</{{ legend_tag }}>{% endif %}

--- a/tests/fields/test_checkboxes.py
+++ b/tests/fields/test_checkboxes.py
@@ -5,7 +5,7 @@ Tests to verify checkboxes are rendered correctly.
 import os
 
 from crispy_forms_gds.helper import FormHelper
-from crispy_forms_gds.layout import Field, Layout
+from crispy_forms_gds.layout import Field, Layout, Size
 from tests.forms import CheckboxesForm
 from tests.utils import TEST_DIR, parse_contents, parse_form
 
@@ -30,7 +30,7 @@ def test_show_legend_as_heading():
     """Verify the field legend can be displayed as the page heading."""
     form = CheckboxesForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(Field("method", context=dict(legend_tag="h1")))
+    form.helper.layout = Layout(Field("method", context={"legend_tag": "h1"}))
     assert parse_form(form) == parse_contents(RESULT_DIR, "legend_heading.html")
 
 
@@ -38,7 +38,9 @@ def test_change_legend_size():
     """Verify size of the field legend can be changed from the default."""
     form = CheckboxesForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(Field("method", context=dict(legend_size="l")))
+    form.helper.layout = Layout(
+        Field("method", context={"legend_size": Size.for_legend("l")})
+    )
     assert parse_form(form) == parse_contents(RESULT_DIR, "legend_size.html")
 
 

--- a/tests/fields/test_file_upload.py
+++ b/tests/fields/test_file_upload.py
@@ -5,7 +5,7 @@ Tests to verify file uploads are rendered correctly.
 import os
 
 from crispy_forms_gds.helper import FormHelper
-from crispy_forms_gds.layout import Field, Layout
+from crispy_forms_gds.layout import Field, Layout, Size
 from tests.forms import FileUploadForm
 from tests.utils import TEST_DIR, parse_contents, parse_form
 
@@ -30,7 +30,7 @@ def test_show_label_as_heading():
     """Verify the field label can be displayed as the page heading."""
     form = FileUploadForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(Field("file", context=dict(label_tag="h1")))
+    form.helper.layout = Layout(Field("file", context={"label_tag": "h1"}))
     assert parse_form(form) == parse_contents(RESULT_DIR, "label_heading.html")
 
 
@@ -38,7 +38,9 @@ def test_change_label_size():
     """Verify size of the field label can be changed from the default."""
     form = FileUploadForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(Field("file", context=dict(label_size="l")))
+    form.helper.layout = Layout(
+        Field("file", context={"label_size": Size.for_label("l")})
+    )
     assert parse_form(form) == parse_contents(RESULT_DIR, "label_size.html")
 
 

--- a/tests/fields/test_radios.py
+++ b/tests/fields/test_radios.py
@@ -5,7 +5,7 @@ Tests to verify radio buttons are rendered correctly.
 import os
 
 from crispy_forms_gds.helper import FormHelper
-from crispy_forms_gds.layout import Field, Layout
+from crispy_forms_gds.layout import Field, Layout, Size
 from tests.forms import RadiosForm
 from tests.utils import TEST_DIR, parse_contents, parse_form
 
@@ -30,7 +30,7 @@ def test_show_legend_as_heading():
     """Verify the field legend can be displayed as the page heading."""
     form = RadiosForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(Field("method", context=dict(legend_tag="h1")))
+    form.helper.layout = Layout(Field("method", context={"legend_tag": "h1"}))
     assert parse_form(form) == parse_contents(RESULT_DIR, "legend_heading.html")
 
 
@@ -38,7 +38,9 @@ def test_change_legend_size():
     """Verify size of the field legend can be changed from the default."""
     form = RadiosForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(Field("method", context=dict(legend_size="l")))
+    form.helper.layout = Layout(
+        Field("method", context={"legend_size": Size.for_legend("l")})
+    )
     assert parse_form(form) == parse_contents(RESULT_DIR, "legend_size.html")
 
 

--- a/tests/fields/test_select.py
+++ b/tests/fields/test_select.py
@@ -5,7 +5,7 @@ Tests to verify selects are rendered correctly.
 import os
 
 from crispy_forms_gds.helper import FormHelper
-from crispy_forms_gds.layout import Field, Layout
+from crispy_forms_gds.layout import Field, Layout, Size
 from tests.forms import SelectForm
 from tests.utils import TEST_DIR, parse_contents, parse_form
 
@@ -30,7 +30,7 @@ def test_show_label_as_heading():
     """Verify the field label can be displayed as the page heading."""
     form = SelectForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(Field("method", context=dict(label_tag="h1")))
+    form.helper.layout = Layout(Field("method", context={"label_tag": "h1"}))
     assert parse_form(form) == parse_contents(RESULT_DIR, "label_heading.html")
 
 
@@ -38,7 +38,9 @@ def test_change_label_size():
     """Verify size of the field label can be changed from the default."""
     form = SelectForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(Field("method", context=dict(label_size="l")))
+    form.helper.layout = Layout(
+        Field("method", context={"label_size": Size.for_label("l")})
+    )
     assert parse_form(form) == parse_contents(RESULT_DIR, "label_size.html")
 
 

--- a/tests/fields/test_text_input.py
+++ b/tests/fields/test_text_input.py
@@ -5,7 +5,7 @@ Tests to verify text fields are rendered correctly.
 import os
 
 from crispy_forms_gds.helper import FormHelper
-from crispy_forms_gds.layout import Field, Layout
+from crispy_forms_gds.layout import Field, Layout, Size
 from tests.forms import TextInputForm
 from tests.utils import TEST_DIR, parse_contents, parse_form
 
@@ -30,7 +30,7 @@ def test_show_label_as_heading():
     """Verify the field label can be displayed as the page heading."""
     form = TextInputForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(Field("name", context=dict(label_tag="h1")))
+    form.helper.layout = Layout(Field("name", context={"label_tag": "h1"}))
     assert parse_form(form) == parse_contents(RESULT_DIR, "label_heading.html")
 
 
@@ -38,7 +38,9 @@ def test_change_label_size():
     """Verify size of the field label can be changed from the default."""
     form = TextInputForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(Field("name", context=dict(label_size="l")))
+    form.helper.layout = Layout(
+        Field("name", context={"label_size": Size.for_label("l")})
+    )
     assert parse_form(form) == parse_contents(RESULT_DIR, "label_size.html")
 
 

--- a/tests/fields/test_textarea.py
+++ b/tests/fields/test_textarea.py
@@ -5,7 +5,7 @@ Tests to verify textareas are rendered correctly.
 import os
 
 from crispy_forms_gds.helper import FormHelper
-from crispy_forms_gds.layout import Field, Layout
+from crispy_forms_gds.layout import Field, Layout, Size
 from tests.forms import TextareaForm
 from tests.utils import TEST_DIR, parse_contents, parse_form
 
@@ -30,7 +30,7 @@ def test_show_label_as_heading():
     """Verify the field label can be displayed as the page heading."""
     form = TextareaForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(Field("description", context=dict(label_tag="h1")))
+    form.helper.layout = Layout(Field("description", context={"label_tag": "h1"}))
     assert parse_form(form) == parse_contents(RESULT_DIR, "label_heading.html")
 
 
@@ -38,7 +38,9 @@ def test_change_label_size():
     """Verify size of the field label can be changed from the default."""
     form = TextareaForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout(Field("description", context=dict(label_size="l")))
+    form.helper.layout = Layout(
+        Field("description", context={"label_size": Size.for_label("l")})
+    )
     assert parse_form(form) == parse_contents(RESULT_DIR, "label_size.html")
 
 

--- a/tests/layout/test_field.py
+++ b/tests/layout/test_field.py
@@ -14,7 +14,7 @@ def test_text_field_defaults():
 
 def test_text_field_label_size():
     field = Field.text("name", label_size=Size.MEDIUM)
-    assert field.context["label_size"] == "m"
+    assert field.context["label_size"] == "govuk-label--m"
     assert field.attrs == {}
 
 
@@ -34,6 +34,12 @@ def test_text_invalid_fixed_width():
         Field.text("name", field_width=1)
 
 
+def test_text_new_fixed_width():
+    field = Field("name", css_class=Fixed.for_input(1, validate=False))
+    assert field.attrs["class"] == "govuk-input--width-1"
+    assert field.context == {}
+
+
 def test_text_field_fluid_width():
     field = Field.text("name", field_width=Fluid.THREE_QUARTERS)
     assert field.attrs["class"] == "govuk-!-width-three-quarters"
@@ -43,3 +49,9 @@ def test_text_field_fluid_width():
 def test_text_invalid_fluid_width():
     with pytest.raises(ValueError):
         Field.text("name", field_width="ninety-percent")
+
+
+def test_text_new_fluid_width():
+    field = Field("name", css_class=Fluid.for_input("one-fifth", validate=False))
+    assert field.attrs["class"] == "govuk-!-width-one-fifth"
+    assert field.context == {}

--- a/tests/layout/test_fieldset.py
+++ b/tests/layout/test_fieldset.py
@@ -5,7 +5,7 @@ Tests to verify selects are rendered correctly.
 import os
 
 from crispy_forms_gds.helper import FormHelper
-from crispy_forms_gds.layout import Fieldset, Layout
+from crispy_forms_gds.layout import Fieldset, Layout, Size
 from tests.forms import FieldsetForm
 from tests.utils import TEST_DIR, parse_contents, parse_form
 
@@ -34,6 +34,6 @@ def test_change_legend_size():
     form = FieldsetForm()
     form.helper = FormHelper()
     form.helper.layout = Layout(
-        Fieldset("name", "email", legend="Contact", legend_size="l")
+        Fieldset("name", "email", legend="Contact", legend_size=Size.for_legend("l"))
     )
     assert parse_form(form) == parse_contents(RESULT_DIR, "legend_size.html")


### PR DESCRIPTION
1. Updated the sphinx configuration to use autodoc for rendering the
   docstrings from classes.

2. Refactored the layout classes to make them easier to document.
   Related classes are grouped together in the same module.

3. Restructured the documents to make it easier to naviage the menu.

4. Simplified the example in the getting started section, spearating
   out a new page on layouts.

5. Fixed the way classes for constants, Size, Colour are configured.
   Now the class generated the complete CSS class names that is added
   to the HTML element.

6. Updated the template so the tag or css class is treated as a single
   item, i.e. the tag is "{{ label_tag }}" and not "h{{ level }}".