### PR TITLE
Added tests to verify default sizes can be set on the FormHelper.

### DIFF
--- a/tests/helpers/results/label_size.html
+++ b/tests/helpers/results/label_size.html
@@ -1,0 +1,14 @@
+<form method="post">
+  <div id="div_id_name" class="govuk-form-group">
+    <label for="id_name" class="govuk-label govuk-label--m">
+      Name
+    </label>
+    <div id="id_name_hint" class="govuk-hint">
+      Help text
+    </div>
+    <input type="text" name="name"
+           aria-describedby="id_name_hint"
+           class="govuk-input"
+           id="id_name">
+  </div>
+</form>

--- a/tests/helpers/results/legend_size.html
+++ b/tests/helpers/results/legend_size.html
@@ -1,0 +1,40 @@
+<form method="post">
+  <div class="govuk-form-group" id="div_id_method">
+    <fieldset class="govuk-fieldset" aria-describedby="id_method_hint">
+
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+        How would you like to be contacted?
+      </legend>
+
+      <div id="id_method_hint" class="govuk-hint">
+        Select all options that are relevant to you.
+      </div>
+
+      <div class="govuk-checkboxes">
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="id_method_1" name="method" type="checkbox" value="email">
+          <label class="govuk-label govuk-checkboxes__label" for="id_method_1">
+            Email
+          </label>
+        </div>
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="id_method_2" name="method" type="checkbox" value="phone">
+          <label class="govuk-label govuk-checkboxes__label" for="id_method_2">
+            Phone
+          </label>
+        </div>
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="id_method_3" name="method" type="checkbox" value="text">
+          <label class="govuk-label govuk-checkboxes__label" for="id_method_3">
+            Text message
+          </label>
+        </div>
+
+      </div>
+
+    </fieldset>
+  </div>
+</form>

--- a/tests/helpers/results/override_label_size.html
+++ b/tests/helpers/results/override_label_size.html
@@ -1,0 +1,14 @@
+<form method="post">
+  <div id="div_id_name" class="govuk-form-group">
+    <label for="id_name" class="govuk-label govuk-label--l">
+      Name
+    </label>
+    <div id="id_name_hint" class="govuk-hint">
+      Help text
+    </div>
+    <input type="text" name="name"
+           aria-describedby="id_name_hint"
+           class="govuk-input"
+           id="id_name">
+  </div>
+</form>

--- a/tests/helpers/results/override_legend_size.html
+++ b/tests/helpers/results/override_legend_size.html
@@ -1,0 +1,40 @@
+<form method="post">
+  <div class="govuk-form-group" id="div_id_method">
+    <fieldset class="govuk-fieldset" aria-describedby="id_method_hint">
+
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+        How would you like to be contacted?
+      </legend>
+
+      <div id="id_method_hint" class="govuk-hint">
+        Select all options that are relevant to you.
+      </div>
+
+      <div class="govuk-checkboxes">
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="id_method_1" name="method" type="checkbox" value="email">
+          <label class="govuk-label govuk-checkboxes__label" for="id_method_1">
+            Email
+          </label>
+        </div>
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="id_method_2" name="method" type="checkbox" value="phone">
+          <label class="govuk-label govuk-checkboxes__label" for="id_method_2">
+            Phone
+          </label>
+        </div>
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="id_method_3" name="method" type="checkbox" value="text">
+          <label class="govuk-label govuk-checkboxes__label" for="id_method_3">
+            Text message
+          </label>
+        </div>
+
+      </div>
+
+    </fieldset>
+  </div>
+</form>

--- a/tests/helpers/test_form_helper.py
+++ b/tests/helpers/test_form_helper.py
@@ -6,8 +6,10 @@ import os
 
 from django.test.html import parse_html
 
-from tests.forms import TextInputForm
-from tests.utils import TEST_DIR, parse_contents, render_template
+from crispy_forms_gds.helper import FormHelper
+from crispy_forms_gds.layout import Field, Layout, Size
+from tests.forms import CheckboxesForm, TextInputForm
+from tests.utils import TEST_DIR, parse_contents, parse_form, render_template
 
 
 RESULT_DIR = os.path.join(TEST_DIR, "helpers", "results")
@@ -28,3 +30,37 @@ def test_error_summary():
     form.add_error(None, "Non-field error")
     page = render_template(template, form=form)
     assert parse_html(page) == parse_contents(RESULT_DIR, "error_summary.html")
+
+
+def test_default_label_size():
+    """Verify a default label size can set for fields."""
+    form = TextInputForm()
+    form.helper = FormHelper(form)
+    form.helper.label_size = Size.for_label("m")
+    assert parse_form(form) == parse_contents(RESULT_DIR, "label_size.html")
+
+
+def test_override_default_label_size():
+    """Verify a default label size can be overridden on the field."""
+    form = TextInputForm()
+    form.helper = FormHelper()
+    form.helper.label_size = Size.for_label("m")
+    form.helper.layout = Layout(Field.text("name", label_size=Size.LARGE))
+    assert parse_form(form) == parse_contents(RESULT_DIR, "override_label_size.html")
+
+
+def test_default_legend_size():
+    """Verify a default legend size can set for fields."""
+    form = CheckboxesForm()
+    form.helper = FormHelper(form)
+    form.helper.legend_size = Size.for_legend("m")
+    assert parse_form(form) == parse_contents(RESULT_DIR, "legend_size.html")
+
+
+def test_override_default_legend_size():
+    """Verify a default legend size can be overridden on the field."""
+    form = CheckboxesForm()
+    form.helper = FormHelper()
+    form.helper.legend_size = Size.for_label("m")
+    form.helper.layout = Layout(Field.checkboxes("method", legend_size=Size.LARGE))
+    assert parse_form(form) == parse_contents(RESULT_DIR, "override_legend_size.html")


### PR DESCRIPTION
Added tests to verify the default size for labels and legends can be set
on the FormHelper instance and overridden on each field as needed.