### PR TITLE
Fixed failing tests when running tox with Django 2.2.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,15 @@ full = $(shell $(PYTHON) setup.py --fullname)
 # Where everything lives
 pip := venv/bin/pip3
 pytest := venv/bin/pytest
+tox := venv/bin/tox
 python := venv/bin/python3
 django := venv/bin/python3 demo/manage.py
 frontend := demo/frontend
 nvm := sh ~/.nvm/nvm.sh
 
+# Rather than a full run with tox just run the tests with
+# a single environment
+testenv := py38-django300
 
 .PHONY: help
 help:
@@ -76,8 +80,8 @@ install: venv dist
 reinstall: clean-dist install
 
 .PHONY: tests
-tests: install
-	$(pytest)
+tests:
+	$(tox) -e $(testenv)
 
 .PHONY: serve
 serve: install $(frontend)/dist

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ help:
 	@echo "  venv        to create the virtualenv and install dependencies"
 	@echo "  dist        to build the package"
 	@echo "  docs        to build the HTML documentation"
-	@echo "  tests    	 to run the lint checks and tests"
-	@echo "  serve    	 to run the Django demo site"
+	@echo "  tests       to run the lint checks and tests"
+	@echo "  serve       to run the Django demo site"
 	@echo
 
 .PHONY: clean-dist

--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,10 @@ full = $(shell $(PYTHON) setup.py --fullname)
 # Where everything lives
 pip := venv/bin/pip3
 pytest := venv/bin/pytest
-tox := venv/bin/tox
 python := venv/bin/python3
 django := venv/bin/python3 demo/manage.py
 frontend := demo/frontend
 nvm := sh ~/.nvm/nvm.sh
-
-# Rather than a full run with tox just run the tests with
-# a single environment
-testenv := py38-django300
 
 .PHONY: help
 help:
@@ -31,7 +26,6 @@ help:
 	@echo "  dist        to build the package"
 	@echo "  docs        to build the HTML documentation"
 	@echo "  install     to install the package in the vitualenv"
-	@echo "  reinstall   to rebuild and reinstall the package in the vitualenv"
 	@echo "  tests    	 to run the lint checks and tests"
 	@echo "  serve    	 to run the Django demo site"
 	@echo
@@ -72,20 +66,13 @@ $(frontend)/dist: $(frontend)/node_modules
 docs:
 	python setup.py build_sphinx
 
-.PHONY: install
-install: venv dist
-	$(pip) install dist/$(full).tar.gz
-
-.PHONY: reinstall
-reinstall: clean-dist install
-
 .PHONY: tests
 tests:
-	$(tox) -e $(testenv)
+	PYTHONPATH=src $(pytest)
 
 .PHONY: serve
-serve: install $(frontend)/dist
-	$(django) migrate
-	$(django) runserver
+serve: $(frontend)/dist
+	PYTHONPATH=src $(django) migrate
+	PYTHONPATH=src $(django) runserver
 
 -include *.mk

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ help:
 	@echo "  venv        to create the virtualenv and install dependencies"
 	@echo "  dist        to build the package"
 	@echo "  docs        to build the HTML documentation"
-	@echo "  install     to install the package in the vitualenv"
 	@echo "  tests    	 to run the lint checks and tests"
 	@echo "  serve    	 to run the Django demo site"
 	@echo
@@ -71,7 +70,7 @@ tests:
 	PYTHONPATH=src $(pytest)
 
 .PHONY: serve
-serve: $(frontend)/dist
+serve: venv $(frontend)/dist
 	PYTHONPATH=src $(django) migrate
 	PYTHONPATH=src $(django) runserver
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ url = https://github.com/wildfish/crispy-forms-gds
 license = BSD 3-Clause Licens
 license_file = LICENCE.txt
 author = Wildfish
-author_email = role@wildfish.com
+author_email = rolo@wildfish.com
 keywords = Django, django-crispy-forms, gov.uk, design system
 classifiers =
     Development Status :: 5 - Production/Stable

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,8 +10,8 @@ long_description_content_type = text/x-rst
 url = https://github.com/wildfish/crispy-forms-gds
 license = BSD 3-Clause Licens
 license_file = LICENCE.txt
-author = Stuart MacKay
-author_email = stuart@wildfish.com
+author = Wildfish
+author_email = role@wildfish.com
 keywords = Django, django-crispy-forms, gov.uk, design system
 classifiers =
     Development Status :: 5 - Production/Stable
@@ -93,10 +93,8 @@ testpaths =
 
 [tox:tox]
 envlist =
-    py35-django{220,300}
-    py36-django{220,300}
-    py37-django{220,300}
-    py38-django{220,300}
+    py35-django220
+    {py36,py37,py38}-django{220,300}
 
 minversion = 3.4.0
 
@@ -110,7 +108,6 @@ deps =
     pytest-cov
 
 commands =
-    make install-packages
     pytest
 
 [build_sphinx]

--- a/src/crispy_forms_gds/layout/content.py
+++ b/src/crispy_forms_gds/layout/content.py
@@ -220,7 +220,7 @@ class HTML(crispy_forms_layout.HTML):
               <tr class="govuk-table__row">
                 {% for item in headings %}
                   <th scope="col" class="govuk-table__header">{{ item }}</th>
-                {% endfor %}  
+                {% endfor %}
               </tr>
             </thead>
             {% endif %}

--- a/src/crispy_forms_gds/templates/gds/field.html
+++ b/src/crispy_forms_gds/templates/gds/field.html
@@ -4,7 +4,7 @@
   {{ field }}
 {% else %}
   {% if max_characters or max_words %}<div class="govuk-character-count" data-module="govuk-character-count"{% if max_characters %} data-maxlength="{{ max_characters }}"{% else %} data-maxwords="{{ max_words }}"{% endif %}{% if threshold %} data-threshold="{{ threshold }}"{% endif %}>{% endif %}
-  <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" class="govuk-form-group {% if form_show_errors%}{% if field.errors %}govuk-form-group--error{% endif %}{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+  <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" class="govuk-form-group{% if form_show_errors%}{% if field.errors %} govuk-form-group--error{% endif %}{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
     {% if field|is_checkboxselectmultiple %}
       {% include 'gds/layout/checkboxes.html' %}

--- a/src/crispy_forms_gds/templates/gds/layout/fieldset.html
+++ b/src/crispy_forms_gds/templates/gds/layout/fieldset.html
@@ -1,5 +1,5 @@
 <fieldset {% if fieldset.css_id %}id="{{ fieldset.css_id }}"{% endif %}
-    {% if fieldset.css_class or form_style %}class="{{ fieldset.css_class }} {{ form_style }}"{% endif %}
+    {% if fieldset.css_class or form_style %}class="{{ fieldset.css_class }}{% if form_style %} {{ form_style }}{% endif %}"{% endif %}
     {{ fieldset.flat_attrs|safe }}>
     {% if legend %}
       <legend class="govuk-fieldset__legend{% if legend_size %} {{ legend_size }}{% endif %}">

--- a/tests/layout/results/accordion/layout.html
+++ b/tests/layout/results/accordion/layout.html
@@ -1,6 +1,6 @@
 <form method="post">
   <div class="govuk-accordion" data-module="govuk-accordion" id="accordion">
-    <div class="govuk-accordion__section ">
+    <div class="govuk-accordion__section">
       <div class="govuk-accordion__section-header">
         <h2 class="govuk-accordion__section-heading">
           <span class="govuk-accordion__section-button">
@@ -15,7 +15,7 @@
         <p>First section contents.</p>
       </div>
     </div>
-    <div class="govuk-accordion__section ">
+    <div class="govuk-accordion__section">
       <div class="govuk-accordion__section-header">
         <h2 class="govuk-accordion__section-heading">
           <span class="govuk-accordion__section-button">


### PR DESCRIPTION
The tests were failing when running with Django 2.2 as parse_html in
Django 3.0 was removing extra spaces from the templates in the class
attribute but 2.2 was not. Updated the templates and now the tests
pass in all environments.

Removed 'make install-packages' from the test command when running tox
since it was an old target and is not needed in any case. Now we just
rely on tox building the sdist and install that into the environment.

Changed the Makefile so 'make tests' now runs the pytest with PYTHONPATH
updated to include the src directory. Previously we were installing the package into the
development venv and running pytest. It sort of worked but caused all
kinds of headaches trying to test local changes. 

(If you look at the inidivdual commits you'll see that running tox in a single target 
environment was also tried but discarded as this latest option is much better).

Updated the makefile to use setting PYTHONPATH=src when running the migrations
and runserver for the Django demo site.

The install and reinstall targets were removed.