### PR TITLE
Added Header, Footer, Skip link and Phase banner components.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and by implication, [Semantic Versioning](http://semver.org/).
 - Merged the templatetags so all you have to do is {% load crispy_forms_gds %}.
 - Added the fields and templates needed for the Date input component.
 - Added template tags for back links, start buttons and breadcrumbs.
+- Added a production-ready base template that can be used in sites.
 
 ## [0.1.0] - 2020-04-28
 ### Added

--- a/demo/backend/components/templates/components/base.html
+++ b/demo/backend/components/templates/components/base.html
@@ -1,105 +1,113 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block sidebar %}
-  <nav>
-    <ul class="govuk-list">
-      <li>
-        <a href="{% url 'components:name' 'accordion' %}"
-           class="govuk-link govuk-link--no-visited-state">
-           {% trans 'Accordion' %}
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'components:name' 'buttons' %}"
-           class="govuk-link govuk-link--no-visited-state">
-           {% trans 'Buttons' %}
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'components:name' 'checkboxes' %}"
-           class="govuk-link govuk-link--no-visited-state">
-           {% trans 'Checkboxes' %}
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'components:name' 'date-input' %}"
-           class="govuk-link govuk-link--no-visited-state">
-           {% trans 'Date input' %}
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'components:name' 'details' %}"
-           class="govuk-link govuk-link--no-visited-state">
-           {% trans 'Details' %}
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'components:name' 'fieldset' %}"
-           class="govuk-link govuk-link--no-visited-state">
-           {% trans 'Fieldset' %}
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'components:name' 'file-upload' %}"
-           class="govuk-link govuk-link--no-visited-state">
-           {% trans 'File upload' %}
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'components:name' 'inset' %}"
-           class="govuk-link govuk-link--no-visited-state">
-           {% trans 'Inset text' %}
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'components:name' 'panel' %}"
-           class="govuk-link govuk-link--no-visited-state">
-           {% trans 'Panel' %}
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'components:name' 'radios' %}"
-           class="govuk-link govuk-link--no-visited-state">
-           {% trans 'Radios' %}
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'components:name' 'select' %}"
-           class="govuk-link govuk-link--no-visited-state">
-           {% trans 'Select' %}
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'components:name' 'tabs' %}"
-           class="govuk-link govuk-link--no-visited-state">
-           {% trans 'Tabs' %}
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'components:name' 'tag' %}"
-           class="govuk-link govuk-link--no-visited-state">
-           {% trans 'Tag' %}
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'components:name' 'text-input' %}"
-           class="govuk-link govuk-link--no-visited-state">
-           {% trans 'Text input' %}
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'components:name' 'textarea' %}"
-           class="govuk-link govuk-link--no-visited-state">
-           {% trans 'Textarea' %}
-        </a>
-      </li>
-      <li>
-        <a href="{% url 'components:name' 'warning' %}"
-           class="govuk-link govuk-link--no-visited-state">
-           {% trans 'Warning text' %}
-        </a>
-      </li>
-    </ul>
-  </nav>
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-quarter">
+      <nav>
+        <ul class="govuk-list">
+          <li>
+            <a href="{% url 'components:name' 'accordion' %}"
+               class="govuk-link govuk-link--no-visited-state">
+               {% trans 'Accordion' %}
+            </a>
+          </li>
+          <li>
+            <a href="{% url 'components:name' 'buttons' %}"
+               class="govuk-link govuk-link--no-visited-state">
+               {% trans 'Buttons' %}
+            </a>
+          </li>
+          <li>
+            <a href="{% url 'components:name' 'checkboxes' %}"
+               class="govuk-link govuk-link--no-visited-state">
+               {% trans 'Checkboxes' %}
+            </a>
+          </li>
+          <li>
+            <a href="{% url 'components:name' 'date-input' %}"
+               class="govuk-link govuk-link--no-visited-state">
+               {% trans 'Date input' %}
+            </a>
+          </li>
+          <li>
+            <a href="{% url 'components:name' 'details' %}"
+               class="govuk-link govuk-link--no-visited-state">
+               {% trans 'Details' %}
+            </a>
+          </li>
+          <li>
+            <a href="{% url 'components:name' 'fieldset' %}"
+               class="govuk-link govuk-link--no-visited-state">
+               {% trans 'Fieldset' %}
+            </a>
+          </li>
+          <li>
+            <a href="{% url 'components:name' 'file-upload' %}"
+               class="govuk-link govuk-link--no-visited-state">
+               {% trans 'File upload' %}
+            </a>
+          </li>
+          <li>
+            <a href="{% url 'components:name' 'inset' %}"
+               class="govuk-link govuk-link--no-visited-state">
+               {% trans 'Inset text' %}
+            </a>
+          </li>
+          <li>
+            <a href="{% url 'components:name' 'panel' %}"
+               class="govuk-link govuk-link--no-visited-state">
+               {% trans 'Panel' %}
+            </a>
+          </li>
+          <li>
+            <a href="{% url 'components:name' 'radios' %}"
+               class="govuk-link govuk-link--no-visited-state">
+               {% trans 'Radios' %}
+            </a>
+          </li>
+          <li>
+            <a href="{% url 'components:name' 'select' %}"
+               class="govuk-link govuk-link--no-visited-state">
+               {% trans 'Select' %}
+            </a>
+          </li>
+          <li>
+            <a href="{% url 'components:name' 'tabs' %}"
+               class="govuk-link govuk-link--no-visited-state">
+               {% trans 'Tabs' %}
+            </a>
+          </li>
+          <li>
+            <a href="{% url 'components:name' 'tag' %}"
+               class="govuk-link govuk-link--no-visited-state">
+               {% trans 'Tag' %}
+            </a>
+          </li>
+          <li>
+            <a href="{% url 'components:name' 'text-input' %}"
+               class="govuk-link govuk-link--no-visited-state">
+               {% trans 'Text input' %}
+            </a>
+          </li>
+          <li>
+            <a href="{% url 'components:name' 'textarea' %}"
+               class="govuk-link govuk-link--no-visited-state">
+               {% trans 'Textarea' %}
+            </a>
+          </li>
+          <li>
+            <a href="{% url 'components:name' 'warning' %}"
+               class="govuk-link govuk-link--no-visited-state">
+               {% trans 'Warning text' %}
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+    <div class="govuk-grid-column-three-quarters">
+      {% block right %}
+      {% endblock %}
+    </div>
+  </div>
 {% endblock %}

--- a/demo/backend/components/templates/components/component.html
+++ b/demo/backend/components/templates/components/component.html
@@ -1,7 +1,7 @@
 {% extends "components/base.html" %}
 {% load i18n crispy_forms_tags crispy_forms_gds %}
 
-{% block content %}
+{% block right %}
 
   {% breadcrumbs breadcrumbs %}
 

--- a/demo/backend/components/templates/components/index.html
+++ b/demo/backend/components/templates/components/index.html
@@ -1,21 +1,25 @@
 {% extends "components/base.html" %}
 {% load i18n crispy_forms_gds %}
 
-{% block content %}
+{% block right %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
 
-  {% url 'home' as back_url %}
-  {% back_link back_url %}
+      {% url 'home' as back_url %}
+      {% back_link back_url %}
 
-  <h1 class="govuk-heading-xl">
-    {% trans "Components" %}
-  </h1>
+      <h1 class="govuk-heading-xl">
+        {% trans "Components" %}
+      </h1>
 
-  <p class="govuk-body govuk-!-margin-bottom-5">
-    {% blocktrans %}
-    Here you will find examples showing how different types of field are displayed
-    using the GOV.UK Design System. Select a link from the sidebar to see each field
-    in more detail.
-    {% endblocktrans %}
-  </p>
+      <p class="govuk-body govuk-!-margin-bottom-5">
+        {% blocktrans %}
+        Here you will find examples showing how different types of field are displayed
+        using the GOV.UK Design System. Select a link from the sidebar to see each field
+        in more detail.
+        {% endblocktrans %}
+      </p>
 
+    </div>
+  </div>
 {% endblock %}

--- a/demo/backend/templates/base.html
+++ b/demo/backend/templates/base.html
@@ -1,35 +1,7 @@
-{% load static i18n %}<!DOCTYPE html>
-<html lang="en" class="govuk-template">
+{% extends "gds/base.html" %}
+{% load i18n crispy_forms_gds %}
 
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  <meta name="theme-color" content="#0b0c0c">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-
-  <title>{% block title %}{% endblock %}</title>
-
-  <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{% static "govuk/images/favicon.ico" %}" type="image/x-icon">
-  <link rel="mask-icon" href="{% static "govuk/images/govuk-mask-icon.svg" %}" color="#0b0c0c">
-  <link rel="apple-touch-icon" sizes="180x180" href="{% static "govuk/images/govuk-apple-touch-icon-180x180.png" %}">
-  <link rel="apple-touch-icon" sizes="167x167" href="{% static "govuk/images/govuk-apple-touch-icon-167x167.png" %}">
-  <link rel="apple-touch-icon" sizes="152x152" href="{% static "govuk/images/govuk-apple-touch-icon-152x152.png" %}">
-  <link rel="apple-touch-icon" href="{% static "govuk/images/govuk-apple-touch-icon.png" %}">
-
-  {% if not WEBPACK_DEV_URL %}
-  <link rel="stylesheet" href="{% static "index.css" %}">
-  {% endif %}
-
-  <meta property="og:image" content="{% static "govuk/images/govuk-opengraph-image.png" %}">
-</head>
-
-<body class="govuk-template__body ">
-  <script>
-    document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-  </script>
-
-  <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
-
+{% block header %}
   <header class="govuk-header" role="banner" data-module="govuk-header">
     <div class="govuk-header__container">
       <div class="govuk-width-container">
@@ -39,23 +11,26 @@
       </div>
     </div>
   </header>
+{% endblock %}
 
+{% block phase_banner %}
   <div class="govuk-phase-banner govuk-width-container" style="border-bottom: none">
     <p class="govuk-phase-banner__content">
       <strong class="govuk-tag govuk-phase-banner__content__tag">
         {% trans "Open" %}
       </strong>
       <span class="govuk-phase-banner__text">
-        {% blocktrans %}
+      {% blocktrans %}
         This is an Open Source project – your
         <a class="govuk-link" href="https://github.com/wildfish/crispy-forms-gds/issues">feedback</a>
         will help us to improve it.
-        {% endblocktrans %}
+      {% endblocktrans %}
       </span>
     </p>
   </div>
+{% endblock %}
 
-  {% block sitenav %}
+{% block extra_header %}
   <nav class="demo-navigation govuk-clearfix">
     <div class="govuk-width-container">
       <ul class="demo-navigation__list">
@@ -67,30 +42,9 @@
       </ul>
     </div>
   </nav>
-  {% endblock %}
+{% endblock %}
 
-  {% block main  %}
-    <div class="govuk-width-container">
-      <main class="govuk-main-wrapper" id="main-content" role="main">
-
-        <div class="govuk-grid-row">
-          {% block alerts %}{% endblock %}
-        </div>
-
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-one-quarter">
-            {% block sidebar %}
-            {% endblock %}
-          </div>
-          <div class="govuk-grid-column-three-quarters">
-            {% block content %}
-            {% endblock %}
-          </div>
-        </div>
-      </main>
-    </div>
-  {% endblock %}
-
+{% block footer %}
   <footer class="govuk-footer " role="contentinfo">
     <div class="govuk-width-container">
       <div class="govuk-footer__meta">
@@ -102,10 +56,4 @@
       </div>
     </div>
   </footer>
-
-  <script src="{% static "index.js" %}"></script>
-  {% block extra_script %}{% endblock %}
-
-</body>
-
-</html>
+{% endblock %}

--- a/demo/backend/templates/index.html
+++ b/demo/backend/templates/index.html
@@ -2,18 +2,23 @@
 {% load i18n crispy_forms_gds %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">
-    {% trans "Demo" %}
-  </h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
 
-  <p class="govuk-body govuk-!-margin-bottom-5">
-    {% blocktrans %}
-      Welcome to the Demo site for <strong>crispy-forms-gds</strong>. Here you will
-      find fully working example of all the components in the GOV.UK Design System.
-    {% endblocktrans %}
-  </p>
+      <h1 class="govuk-heading-xl">
+        {% trans "Demo" %}
+      </h1>
 
-  {% url 'components:index' as start_url %}
-  {% button_start start_url "Start now" %}
+      <p class="govuk-body govuk-!-margin-bottom-5">
+        {% blocktrans %}
+          Welcome to the Demo site for <strong>crispy-forms-gds</strong>. Here you will
+          find fully working example of all the components in the GOV.UK Design System.
+        {% endblocktrans %}
+      </p>
 
+      {% url 'components:index' as start_url %}
+      {% button_start start_url "Start now" %}
+
+    </div>
+  </div>
 {% endblock %}

--- a/docs/components/footer.rst
+++ b/docs/components/footer.rst
@@ -1,0 +1,20 @@
+.. _Footer: https://design-system.service.gov.uk/components/footer/
+
+######
+Footer
+######
+There is a `Footer`_ component implemented in the ``gds/base.html`` template that
+is include in the template pack. It is wrapped with a block tag ``{% block footer %}``
+so if you extend the base template you can override it if you need to.
+
+Currently the footer only contains the meta information from the Design System site,
+which includes the licence terms and the crown copyright symbol. This is wrapped
+in a ``{% block footer__meta %}`` tag.
+
+.. note::
+    The footer__meta block is specifically overridden in the Demo site as Wildfish
+    does not have permission to display the crown copyright symbol.
+
+There is also an empty block for site navigation, ``{% block footer__navigation %}``, but
+it is really only intended as a guide - the footer section has quite a bit of variation
+since the content is tied completely to the implementation of each site.

--- a/docs/components/header.rst
+++ b/docs/components/header.rst
@@ -1,0 +1,21 @@
+.. _Header: https://design-system.service.gov.uk/components/header/
+
+######
+Header
+######
+There is a `Header`_ component implemented in the ``gds/base.html`` template that
+is include in the template pack. It is wrapped with a block tag, ``{% block hjeader %}``
+so if you extend the base template you can override it if you need to.
+
+The block implements the "Service name with navigation" variation of the different headers shown
+on the Design System page. There are two main daughter blocks ``{% block header__logo %}``
+for displaying the crown logo and "GOV.UK" and ``{% block header__service %}``
+
+.. note::
+    The header__logo block is specifically overridden in the Demo site as Wildfish
+    does not have permission to display the crown logo.
+
+Within ``{% block header__service %}`` there are three further blocks: ``{% block header__service__url %}``
+and ``{% block header__service__name %}`` where you can set the URL, and name for your site
+and ``{% block header__service__navigation %}`` where you can set navigation links for
+your site. This block is left empty for now.

--- a/docs/components/index.rst
+++ b/docs/components/index.rst
@@ -20,18 +20,20 @@ encounter in a complex form.
     details
     fieldset
     file
+    footer
+    header
     inset
     panel
+    phase_banner
     radios
     select
+    skip_link
     tabs
     tag
     text
     textarea
     warning
 
-The remaining components in the Design System list: `Footer`, `Header`,
-`Phase panel` and `Skip link` are page-level components and probably have limited utility
-within a form nd are not supported, as yet. However `Summary list` has the potential for
-being used in a form. We are just not sure how to implement it, given that the list contents
-and specifically actions can be laid out in various ways.
+The only Design System component not in this list is `Summary list`. Right now we are
+just not sure how to implement it, given that the list contents and specifically
+actions can be laid out in various ways.

--- a/docs/components/phase_banner.rst
+++ b/docs/components/phase_banner.rst
@@ -1,0 +1,13 @@
+.. _Phase banner: https://design-system.service.gov.uk/components/phase-banner/
+
+############
+Phase banner
+############
+There is a `Phase banner`_ component implemented in the ``gds/base.html`` template
+that is include in the template pack. It is wrapped with a ``{% block %}`` tag so if
+you extend the base template you can override it if you need to.
+
+Within the ``{% block phase_banner %}`` tag there are two daughter blocks:
+``{% block phase_banner__tag %}`` and ``{% block phase_banner__text %}`` so you can
+selectively override these if you don't want to override the entire phase_banner
+block.

--- a/docs/components/skip_link.rst
+++ b/docs/components/skip_link.rst
@@ -1,0 +1,8 @@
+.. _Skip link: https://design-system.service.gov.uk/components/skip-link/
+
+#########
+Skip link
+#########
+There is a `Skip link`_ component implemented in the header of the ``gds/base.html``
+template that is include in the template pack. It is wrapped with a ``{% block %}``
+tag so if you extend the base template you can override it if you need to.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,7 @@ for the `GOV.UK Design System`_.
     reference/form/index
     reference/layout/index
     reference/settings
+    reference/templates
     reference/templatetags
     reference/filters
 

--- a/docs/reference/filters.rst
+++ b/docs/reference/filters.rst
@@ -57,27 +57,3 @@ Return ``True`` if the field belongs to a Radios component, ``False`` otherwise.
 
     {% if field|is_radioselect %}
 
-
-lookup
-======
-Looks up a value from a dict. Because Django still does not have this.
-
-.. sourcecode:: html+django
-
-    {{ dict|lookup:key }}
-
-It's used when displaying the hint, if one is available for an item in
-a list of checkboxes or radio buttons.
-
-pop
-===
-Removes a value from a dict and displays it
-
-.. sourcecode:: html+django
-
-    {{ dict|pop:key }}
-
-This is used when displaying the label for the individual fields in a
-Date input component. The label was added as a widget attribute - it was
-the only way to smuggle it in - and it needs to be remove from so it does
-not get rendered as an attribute on the <input> element.

--- a/docs/reference/templates.rst
+++ b/docs/reference/templates.rst
@@ -1,0 +1,16 @@
+=========
+Templates
+=========
+
+Crispy-forms-gds contains a base template, ``gds/base.html`` that is production ready
+and can be used in your site. The template has several ``{% block %}`` tags which allow
+various aspects of the template to be customised. The description of the ``Header``,
+``Footer``, ``Skip link`` and ``Phase banner`` components in the ``Components`` section
+describe each of the available blocks.
+
+.. note::
+    IMPORTANT: The template contains <svg> elements to display the crown and crown
+    copyright logos. These are included as a convenience for projects and sites that
+    are part of Her Majesty's Government. If your project is not directly part of
+    the Government of the United Kingdom you expressly DO NOT have permission to display
+    these logos and these sections must be overridden.

--- a/src/crispy_forms_gds/templates/gds/base.html
+++ b/src/crispy_forms_gds/templates/gds/base.html
@@ -1,0 +1,132 @@
+{% load static i18n %}<!DOCTYPE html>
+<html lang="en" class="govuk-template">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="#0b0c0c">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+  <title>{% block title %}{% endblock %}</title>
+
+  <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{% static "govuk/images/favicon.ico" %}" type="image/x-icon">
+  <link rel="mask-icon" href="{% static "govuk/images/govuk-mask-icon.svg" %}" color="#0b0c0c">
+  <link rel="apple-touch-icon" sizes="180x180" href="{% static "govuk/images/govuk-apple-touch-icon-180x180.png" %}">
+  <link rel="apple-touch-icon" sizes="167x167" href="{% static "govuk/images/govuk-apple-touch-icon-167x167.png" %}">
+  <link rel="apple-touch-icon" sizes="152x152" href="{% static "govuk/images/govuk-apple-touch-icon-152x152.png" %}">
+  <link rel="apple-touch-icon" href="{% static "govuk/images/govuk-apple-touch-icon.png" %}">
+
+  {% if not WEBPACK_DEV_URL %}
+  <link rel="stylesheet" href="{% static "index.css" %}">
+  {% endif %}
+
+  <meta property="og:image" content="{% static "govuk/images/govuk-opengraph-image.png" %}">
+</head>
+
+<body class="govuk-template__body ">
+  <script>
+    document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+  </script>
+
+  {% block skip_link %}
+    <a href="#main-content" class="govuk-skip-link">{% trans 'Skip to main content' %}</a>
+  {% endblock %}
+
+  {% block header %}
+    <header class="govuk-header" role="banner" data-module="govuk-header">
+      <div class="govuk-header__container govuk-width-container">
+
+        {% block header__logo %}
+        <div class="govuk-header__logo">
+          <a href="#" class="govuk-header__link govuk-header__link--homepage">
+            <span class="govuk-header__logotype">
+              <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="30" width="36">
+                <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+                <image src="/assets/images/govuk-logotype-crown.png" xlink:href="" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
+              </svg>
+              <span class="govuk-header__logotype-text">
+                GOV.UK
+              </span>
+            </span>
+          </a>
+        </div>
+        {% endblock %}
+
+        {% block header__service %}
+          <div class="govuk-header__content">
+            <a href="{% block header__service__url %}{% endblock %}" class="govuk-header__link govuk-header__link--service-name">
+              {% block header__service__name %}
+              {% endblock %}
+            </a>
+            {% block header__service__navigaton %}
+            {% endblock %}
+          </div>
+        {% endblock %}
+
+      </div>
+    </header>
+
+  {% endblock %}
+
+  {% block phase_banner %}
+    <div class="govuk-phase-banner govuk-width-container">
+      <p class="govuk-phase-banner__content">
+        <strong class="govuk-tag govuk-phase-banner__content__tag">
+          {% block phase_banner__tag %}
+          {% endblock %}
+        </strong>
+        <span class="govuk-phase-banner__text">
+          {% block phase_banner__text %}
+          {% endblock %}
+        </span>
+      </p>
+    </div>
+  {% endblock %}
+
+  {% block extra_header %}
+  {% endblock %}
+
+  {% block main %}
+    <div class="govuk-width-container">
+      <main class="govuk-main-wrapper" id="main-content" role="main">
+        {% block content %}
+        {% endblock %}
+      </main>
+    </div>
+  {% endblock %}
+
+  {% block footer %}
+    <footer class="govuk-footer " role="contentinfo">
+      <div class="govuk-width-container ">
+
+        {% block footer__navigation %}
+        {% endblock %}
+
+        {% block footer__meta %}
+          <div class="govuk-footer__meta">
+            <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+
+              <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
+                <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+              </svg>
+              <span class="govuk-footer__licence-description">
+                All content is available under the
+                <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+              </span>
+            </div>
+            <div class="govuk-footer__meta-item">
+              <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+            </div>
+          </div>
+        {% endblock %}
+
+      </div>
+    </footer>
+  {% endblock %}
+
+  <script src="{% static "index.js" %}"></script>
+  {% block extra_script %}{% endblock %}
+
+</body>
+
+</html>


### PR DESCRIPTION
Added a base template, which is based on the production-ready template
available from the Design System site. The template contains the HTML
to implement the Header, Footer, Skip link and Phase banner components.
The components and parts of the components are wrapped in {% block %}
tags to make it easy to use the template in various project with the
respective blocks customised as required.