### PR TITLE
Added support for adding css classes to HTML.table.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and by implication, [Semantic Versioning](http://semver.org/).
 - Added the fields and templates needed for the Date input component.
 - Added template tags for back links, start buttons and breadcrumbs.
 - Added a production-ready base template that can be used in sites.
+### Changed
+- Updated Table component to support a caption and CSS styling.
 
 ## [0.1.0] - 2020-04-28
 ### Added

--- a/demo/backend/components/forms/tabs.py
+++ b/demo/backend/components/forms/tabs.py
@@ -34,18 +34,24 @@ class TabsForm(forms.Form):
         self.helper.layout = Layout(
             Tabs(
                 TabPanel(
-                    "Past day", HTML.h1("Past day"), HTML.table(headings, past_day)
+                    "Past day",
+                    HTML.h1("Past day"),
+                    HTML.table(None, headings, past_day),
                 ),
                 TabPanel(
-                    "Past week", HTML.h1("Past week"), HTML.table(headings, past_week)
+                    "Past week",
+                    HTML.h1("Past week"),
+                    HTML.table(None, headings, past_week),
                 ),
                 TabPanel(
                     "Past month",
                     HTML.h1("Past month"),
-                    HTML.table(headings, past_month),
+                    HTML.table(None, headings, past_month),
                 ),
                 TabPanel(
-                    "Past year", HTML.h1("Past year"), HTML.table(headings, past_year)
+                    "Past year",
+                    HTML.h1("Past year"),
+                    HTML.table(None, headings, past_year),
                 ),
             )
         )

--- a/docs/components/index.rst
+++ b/docs/components/index.rst
@@ -28,6 +28,7 @@ encounter in a complex form.
     radios
     select
     skip_link
+    table
     tabs
     tag
     text

--- a/docs/components/table.rst
+++ b/docs/components/table.rst
@@ -1,0 +1,53 @@
+.. _Table: https://design-system.service.gov.uk/components/table/
+
+#####
+Table
+#####
+A `Table`_ component is implemented using the ``HTML.table()`` class method
+to generate the HTML object that can be added to a form::
+
+    def __init__(self, *args, **kwargs):
+        super(TabsForm, self).__init__(*args, **kwargs)
+
+        caption = "This week"
+        headers = ["Case manager", "Cases opened", "Cases closed"]
+        rows = [
+            ["David Francis", "24", "18"],
+            ["Paul Farmer", "16", "20"],
+            ["Rita Patel", "24", "27"],
+        ]
+        header_css = [
+            "govuk-!-width-one-half",
+            "govuk-table__header--numeric",
+            "govuk-table__header--numeric",
+        ]
+        row_css = [
+            "",
+            "govuk-table__cell--numeric",
+            "govuk-table__cell--numeric"
+        ]
+
+        self.helper = FormHelper()
+        self.helper.layout = Layout(
+            HTML.table(caption, headers, rows, header_css, row_css)
+        )
+
+The method is simple to use but rather basic. The caption and the header are
+optional. Set them to ``None`` if not needed. The number of columns in the
+header and each row should match - you cannot leave entries out if the contents
+are blank.
+
+The Design System CSS classes needed to style the table are added
+by default. You can add additional classes to set the column widths or alignment
+by passing one or more CSS classes as a string in the ``header_css`` or ``row_css``
+arguments.
+
+The method works perfectly well for small amounts of data, particularly on
+public-facing pages where the intent is just data presentation. For more
+sophisticated uses where the volume of data is large and splitting the table
+across pages or being able to sort data in columns is needed then consider
+looking at a package such `django-tables2`_.
+
+.. _django-tables2: https://django-tables2.readthedocs.io/en/latest/
+
+

--- a/docs/components/tabs.rst
+++ b/docs/components/tabs.rst
@@ -43,10 +43,14 @@ of each panel and a parent ``Tabs`` which contains the list of panels. ::
             self.helper.layout = Layout(
                 Tabs(
                     TabPanel(
-                        "Past day", HTML.h1("Past day"), HTML.table(headings, past_day)
+                        "Past day",
+                        HTML.h1("Past day"),
+                        HTML.table(None, headings, past_day)
                     ),
                     TabPanel(
-                        "Past week", HTML.h1("Past week"), HTML.table(headings, past_week)
+                        "Past week",
+                        HTML.h1("Past week"),
+                        HTML.table(None, headings, past_week)
                     ),
                     TabPanel(
                         "Past month",
@@ -54,7 +58,9 @@ of each panel and a parent ``Tabs`` which contains the list of panels. ::
                         HTML.table(headings, past_month),
                     ),
                     TabPanel(
-                        "Past year", HTML.h1("Past year"), HTML.table(headings, past_year)
+                        "Past year",
+                        HTML.h1("Past year"),
+                        HTML.table(None, headings, past_year)
                     ),
                 )
             )

--- a/src/crispy_forms_gds/layout/content.py
+++ b/src/crispy_forms_gds/layout/content.py
@@ -179,34 +179,76 @@ class HTML(crispy_forms_layout.HTML):
         return HTML(snippet)
 
     @classmethod
-    def table(cls, headings, data):
+    def table(cls, caption, headers, rows, header_css=None, row_css=None):
         """
         .. _Table: https://design-system.service.gov.uk/components/table/
 
         Generate the layout for an `Table`_ component.
 
+        Eaxample: ::
+
+            caption = "Dates and amounts"
+            headers = ["Date", "Amount"]
+
+            header_css = [
+                "govuk-!width-one-half",
+                "govuk-table__header--numeric govuk-!width-one-half"
+            ]
+
+            rows = [
+                ["First six weeks (per week)", "£109.80"]
+                ["Next 33 weeks (per week)", "£109.80"]
+                [Total estimated pay", "£4,282.20"]
+            ]
+
+            row_css = ["". "govuk-table__cell--numeric"]
+
+            self.helper.layout = Layout(
+                HTML.table(caption, headers, rows, header_css, row_css)
+            )
+
+
         Args:
-            headings: the list of heading for the columns.
-            data: the list of contents for each row - a list of lists of strings.
+            caption (str, optional): a caption describing the table.
+
+            headers: the list of heading for the columns.
+
+            rows: a two dimensional list containing the data for each cell.
+
+            header_css (list): css classes that will be added to each column in the header.
+
+            row_css (list): css classes that will be added to each column in each row
 
         """
-        context = Context(dict(headings=headings, data=data))
+        if not header_css:
+            header_css = [""] * len(headers)
+
+        if not row_css:
+            row_css = [""] * len(headers)
+
+        headers = zip(headers, header_css)
+        rows = [zip(row, row_css) for row in rows]
+
+        context = Context(dict(caption=caption, headers=headers, rows=rows))
         template = """
             <table class="govuk-table">
-            {% if headings %}
+            {% if caption %}
+              <caption class="govuk-table__caption">{{ caption }}</caption>
+            {% endif %}
+            {% if headers %}
             <thead class="govuk-table__head">
               <tr class="govuk-table__row">
-                {% for item in headings %}
-                  <th scope="col" class="govuk-table__header">{{ item }}</th>
+                {% for col in headers %}
+                  <th scope="col" class="govuk-table__header{% if col.1 %} {{ col.1 }}{% endif %}">{{ col.0 }}</th>
                 {% endfor %}
               </tr>
             </thead>
             {% endif %}
             <tbody class="govuk-table__body">
-              {% for row in data %}
+              {% for row in rows %}
                 <tr class="govuk-table__row">
-                  {% for item in row %}
-                    <td class="govuk-table__cell">{{ item }}</td>
+                  {% for col in row %}
+                    <td class="govuk-table__cell{% if col.1 %} {{ col.1 }}{% endif %}">{{ col.0 }}</td>
                   {% endfor %}
                 </tr>
               {% endfor %}

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -105,6 +105,23 @@ class TextareaForm(BaseForm):
     )
 
 
+class TableForm(forms.Form):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        header = ["Case worker", "Number of cases closed"]
+        rows = [["David Francis", 3], ["Paul Farmer", 1]]
+        header_css = [
+            "govuk-!-width-one-half",
+            "govuk-!-width-one-half govuk-table__header--numeric",
+        ]
+        row_css = ["", "govuk-table__cell--numeric"]
+
+        self.helper = FormHelper()
+        self.helper.layout = Layout(
+            HTML.table("Caption", header, rows, header_css, row_css)
+        )
+
+
 class TabsForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/layout/results/table/layout.html
+++ b/tests/layout/results/table/layout.html
@@ -1,0 +1,21 @@
+<form method="post">
+  <table class="govuk-table">
+    <caption class="govuk-table__caption">Caption</caption>
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header govuk-!-width-one-half">Case worker</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-half govuk-table__header--numeric">Number of cases closed</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">David Francis</td>
+        <td class="govuk-table__cell govuk-table__cell--numeric">3</td>
+      </tr>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">Paul Farmer</td>
+        <td class="govuk-table__cell govuk-table__cell--numeric">1</td>
+      </tr>
+    </tbody>
+  </table>
+</form>

--- a/tests/layout/test_table.py
+++ b/tests/layout/test_table.py
@@ -1,0 +1,17 @@
+"""
+Tests to verify tables are rendered correctly.
+
+"""
+import os
+
+from tests.forms import TableForm
+from tests.utils import TEST_DIR, parse_contents, parse_form
+
+
+RESULT_DIR = os.path.join(TEST_DIR, "layout", "results", "table")
+
+
+def test_basic_layout():
+    """Verify all the gds attributes are displayed."""
+    form = TableForm()
+    assert parse_form(form) == parse_contents(RESULT_DIR, "layout.html")


### PR DESCRIPTION
Also added a separate page for Table to the Components section of
the docs. Previously the layout of a table was indirectly covered
in the docs for Tabs. Now that css support has been added and the
other page level elements recently added were also deocumented it
makes more sense to have a separate page.