### PR TITLE
Disabled isort in testing as there are conflicts with black.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -85,7 +85,7 @@ exclude =
     docs
 
 [tool:pytest]
-addopts = --black --flake8 --isort --cov=src --cov-report=term --cov-report=html
+addopts = --black --flake8 --cov=src --cov-report=term --cov-report=html
 python_files =
     test_*.py
 testpaths =


### PR DESCRIPTION
Black insists that pytest imports are a third-party:

    import pytest
    from crispy_forms_gds.lauout import HTML

But iSort insists that 'import' is separated from 'from'

    import pytest

    from crispy_forms_gds.lauout import HTML

The "black" form is set when the file is saved and that triggers a
test failure. Since we are also running iSort on file saves we are
going to leave that in place and remove the checking in the tests.