### PR TITLE
Set the correct table on field labels on the Text input example.

### DIFF
--- a/demo/backend/components/forms/text_input.py
+++ b/demo/backend/components/forms/text_input.py
@@ -29,7 +29,7 @@ class TextInputForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()
-        self.helper.label_size = Size.SMALL
+        self.helper.label_size = Size.for_label(Size.SMALL)
         self.helper.layout = Layout(
             Fieldset(
                 Field.text("name"),


### PR DESCRIPTION
In the form for the Text input component page the default size for the
the field labels was being set to small. However the size, 's', was being
set directly on the FieldHelper when the class, 'govuk-label--s', should
have been set instead.