### PR TITLE
Fix bug when compressing empty values in DateInputField

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,30 @@
 os: linux
 dist: xenial
 language: python
+python:
+  - "3.6"
+  - "3.7"
+  - "3.8"
 before_install:
-- pip install --upgrade pip wheel setuptools codecov
+- pip install --upgrade pip wheel setuptools codecov tox-travis
 install:
-- pip install -r requirements.txt
+- pip install -r requirements/dev.in
 script:
 - tox
-jobs:
+matrix:
   include:
-  - python: '3.5'
-    env: TOXENV=py35-django220
   - python: '3.6'
-    env: TOXENV=py36-django220
+    env: TOXENV=py36-django22
   - python: '3.6'
-    env: TOXENV=py36-django300
+    env: TOXENV=py36-django30
   - python: '3.7'
-    env: TOXENV=py37-django220
+    env: TOXENV=py37-django22
   - python: '3.7'
-    env: TOXENV=py37-django300
+    env: TOXENV=py37-django30
   - python: '3.8'
-    env: TOXENV=py38-django220
+    env: TOXENV=py38-django22
   - python: '3.8'
-    env: TOXENV=py38-django300
+    env: TOXENV=py38-django30
 after_success:
 - codecov
 deploy:

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,13 +23,13 @@ search = version = "{current_version}"
 replace = version = "{new_version}"
 
 [bumpversion:file:CHANGELOG.rst]
-search = 
+search =
 	Latest
 	------
-replace = 
+replace =
 	Latest
 	------
-	
+
 	{new_version} ({now:%%Y-%%m-%%d})
 	------------------
 
@@ -38,12 +38,12 @@ search = version="{current_version}"
 replace = version="{new_version}"
 
 [flake8]
-extend_exclude = 
+extend_exclude =
 	*/migrations/*,
 	build/,
 	docs/,
 	venv/
-ignore = 
+ignore =
 	E123, ; closing bracket does not match indentation of opening bracket’s line
 	W503  ; line break before binary operator
 max-line-length = 88
@@ -59,25 +59,25 @@ line_length = 88
 default_section = THIRDPARTY
 known_django = django
 known_first_party = crispy_forms_gds
-sections = 
+sections =
 	FUTURE,
 	STDLIB,
 	DJANGO,
 	THIRDPARTY,
 	FIRSTPARTY,
 	LOCALFOLDER
-skip = 
+skip =
 	migrations,
 	venv
 
 [tool:pytest]
-testpaths = 
+testpaths =
 	tests
 
 [coverage:run]
 branch = true
 data_file = .coverage
-omit = 
+omit =
 	tests/*
 	demo/*
 	venv/*
@@ -86,7 +86,7 @@ omit =
 show_missing = True
 skip_covered = True
 fail_under = 30
-exclude_lines = 
+exclude_lines =
 	raise AssertionError
 	raise NotImplementedError
 
@@ -94,20 +94,22 @@ exclude_lines =
 directory = reports/coverage
 
 [tox:tox]
-envlist = 
-	{py36,py37,py38}-django{22,30,31}
+envlist =
+	py{36,37,38}-django22
+	py{36,37,38}-django30
+	py{36,37,38}-django31
 
 [testenv:docs]
 basepython = python
 changedir = docs
 deps = -r requirements/docs.txt
-commands = 
+commands =
 	sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [testenv]
 commands = pytest
 deps = -r requirements/tests.txt
-setenv = 
+setenv =
 	PYTHONPATH = src
 
 [wheel]

--- a/src/crispy_forms_gds/fields.py
+++ b/src/crispy_forms_gds/fields.py
@@ -105,7 +105,7 @@ class DateInputField(forms.MultiValueField):
                         self.error_messages["required"], code="required"
                     )
                 else:
-                    return self.compress([])
+                    return self.compress([None, None, None])
         else:
             raise ValidationError(self.error_messages["invalid"], code="invalid")
         for i, field in enumerate(self.fields):

--- a/tests/fields/test_date_input_field.py
+++ b/tests/fields/test_date_input_field.py
@@ -27,6 +27,14 @@ def test_compress_optional_fields_empty():
     assert value is None
 
 
+def test_clean_optional_fields_empty():
+    """Verify clean returns None if the values are not required and not set."""
+    field = DateInputField(required=False)
+    field.require_all_fields = False
+    value = field.clean(["", "", ""])
+    assert value is None
+
+
 def test_cleaned_valid_value():
     """Verify the Date input field returns a date object."""
     date = datetime.date(year=2007, month=12, day=11)


### PR DESCRIPTION
Currently when compressing empty values in DateInputField
and empty list is passed to `.compress`, `.compress` expects
a list of at least 3 values. So this raises an error.

This commit passes a list of 3 `None` values instead which
`.compress` handles appropriately.

This fixes #57 