### PR TITLE
Raise ValuationError if invalid date entered in DateInputField

### DIFF
--- a/src/crispy_forms_gds/fields.py
+++ b/src/crispy_forms_gds/fields.py
@@ -162,6 +162,9 @@ class DateInputField(forms.MultiValueField):
         """
         day, month, year = data_list
         if day and month and year:
-            return date(day=int(day), month=int(month), year=int(year))
+            try:
+                return date(day=int(day), month=int(month), year=int(year))
+            except ValueError as e:
+                raise ValidationError(str(e)) from e
         else:
             return None

--- a/tests/fields/test_date_input_field.py
+++ b/tests/fields/test_date_input_field.py
@@ -11,6 +11,17 @@ import pytest
 from crispy_forms_gds.fields import DateInputField
 
 
+def test_compress_invalid_fields():
+    """Verify compress raises an error on an invalid date."""
+    day = 30
+    month = 2
+    year = 2021
+    field = DateInputField()
+    with pytest.raises(ValidationError) as err:
+        field.compress([day, month, year])
+    assert str(err) == "day is out of range for month"
+
+
 def test_compress_valid_fields():
     """Verify compress returns a date."""
     date = datetime.date(year=2007, month=12, day=11)


### PR DESCRIPTION
Fix crash which occurs when invalid dates are compressed.