### PR TITLE
Add a password field to Text Input components page

### DIFF
--- a/demo/backend/components/forms/text_input.py
+++ b/demo/backend/components/forms/text_input.py
@@ -17,13 +17,25 @@ from crispy_forms_gds.layout import (
 class TextInputForm(forms.Form):
 
     name = forms.CharField(
-        label="Your name", help_text="Enter your name as it appears on your passport.",
+        label="Your name",
+        help_text="Enter your name as it appears on your passport.",
     )
 
-    email = forms.CharField(label="Email", help_text="Enter your email address.",)
+    email = forms.CharField(
+        label="Email",
+        help_text="Enter your email address.",
+        widget=forms.EmailInput,
+    )
 
     phone = forms.CharField(
-        label="Phone", help_text="Enter your home or mobile telephone number.",
+        label="Phone",
+        help_text="Enter your home or mobile telephone number.",
+    )
+
+    password = forms.CharField(
+        label="Password",
+        help_text="Enter your password.",
+        widget=forms.PasswordInput,
     )
 
     def __init__(self, *args, **kwargs):
@@ -35,6 +47,7 @@ class TextInputForm(forms.Form):
                 Field.text("name"),
                 Field.text("email", field_width=Fluid.TWO_THIRDS),
                 Field.text("phone", field_width=Fixed.TEN),
+                Field.text("password", field_width=Fluid.ONE_HALF),
             ),
             Button("submit", "Submit"),
         )
@@ -42,12 +55,22 @@ class TextInputForm(forms.Form):
     def valid_layout(self):
         name = self.cleaned_data["name"]
         email = self.cleaned_data["email"]
+        password = self.cleaned_data["password"]
         phone = self.cleaned_data["phone"]
         self.helper.layout = Layout(
             Hidden("name", name),
             Hidden("email", email),
+            Hidden("password", password),
             Hidden("phone", phone),
             HTML.h2("You answered..."),
-            HTML.table(None, [("Name:", name), ("Email:", email), ("Phone:", phone)]),
+            HTML.table(
+                None,
+                [
+                    ("Name:", name),
+                    ("Email:", email),
+                    ("Phone:", phone),
+                    ("Password:", password),
+                ],
+            ),
             Button("continue", "Continue"),
         )


### PR DESCRIPTION
Show how to use a widget other than the default TextInput widget for a CharField. Add a password field to the form and update the email field to use an EmailInput widget.

The changes also include reformatting performed automatically by black.