### PR TITLE
Remove the text "Warning" from warning

### DIFF
--- a/src/crispy_forms_gds/layout/content.py
+++ b/src/crispy_forms_gds/layout/content.py
@@ -298,7 +298,7 @@ class HTML(crispy_forms_layout.HTML):
             <div class="govuk-warning-text">
               <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
               <strong class="govuk-warning-text__text">
-                <span class="govuk-warning-text__assistive">Warning</span>
+                <span class="govuk-visually-hidden>Warning</span>
                 %s
               </strong>
             </div>


### PR DESCRIPTION
The gov uk design system doesn't show the text "Warning" in the Warning text, just the warning text icon and the actual text. This change makes the text "Warning" hidden to make it consistent with govuk design system

Referemce: https://design-system.service.gov.uk/components/warning-text/