### PR TITLE
fix: add govuk-input--error to email input with errors

### DIFF
--- a/src/crispy_forms_gds/templatetags/crispy_forms_gds.py
+++ b/src/crispy_forms_gds/templatetags/crispy_forms_gds.py
@@ -343,7 +343,7 @@ class CrispyGDSFieldNode(template.Node):
 
                     widget_class_name = widget.__class__.__name__
 
-                    if widget_class_name in ["Select", "TextInput", "Textarea"]:
+                    if widget_class_name in ["EmailInput", "Select", "TextInput", "Textarea"]:
                         if is_multivalue(field):
                             if error_count == 0:
                                 css_class += " govuk-input--error"


### PR DESCRIPTION
`EmailInput` was missing from the list of input types that the `govuk-input--error` is added to.

In the email input example on the `README.md` it also shows the missing red input border, so that would need to be updated if this gets merged.